### PR TITLE
Missing Summaries and Missing Episodes logs

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -303,39 +303,16 @@ class HamaCommonAgent:
             currentEpNum     = getElementText(episode, 'EpisodeNumber')
             currentAbsNum    = getElementText(episode, 'absolute_number')
 			
-            if len(media.seasons)>2 or max(map(int, media.seasons.keys()))>1 or metadata.id.startswith("tvdb"):
-              if '1' in media.seasons and len(media.seasons)==1:
-                numbering = "s1e%s" % currentAbsNum
-              elif '0' in media.seasons and '1' in media.seasons and len(media.seasons)==2:
-                if currentSeasonNum == '0':
-                  numbering = "s0e" + currentEpNum
-                else:
-                  numbering = "s1e" + currentAbsNum
-              else:
-                if metadata.id.startswith("tvdb2-"):
-                  numbering = "s" + currentSeasonNum + "e" + currentEpNum
-                elif metadata.id.startswith("tvdb3-"):
-                  if currentSeasonNum == '0':
-                    numbering = "s" + currentSeasonNum + "e" + currentEpNum
-                  else:
-                    numbering = "s" + currentSeasonNum + "e" + currentAbsNum
-                else:
-                  numbering = "s" + currentSeasonNum + "e" + currentEpNum
-            else:
-              if defaulttvdbseason=="a":
-                numbering = currentAbsNum
-              else:
-                numbering = "s" + currentSeasonNum + "e" + currentEpNum
+            if defaulttvdbseason=="a": numbering = currentAbsNum
+            else:                      numbering = "s" + currentSeasonNum + "e" + (currentEpNum if currentSeasonNum == '0' or not metadata.id.startswith("tvdb3-") else currentAbsNum)
             tvdb_table [numbering] = { 'EpisodeName': getElementText(episode, 'EpisodeName'), 'FirstAired':  getElementText(episode, 'FirstAired' ),
                                        'filename':    getElementText(episode, 'filename'   ), 'Overview':    getElementText(episode, 'Overview'   ), 
                                        'Rating':      getElementText(episode, 'Rating'     ) if '.' in getElementText(episode, 'Rating') else None,
                                        'Director':    getElementText(episode, 'Director'   ), 'Writer':      getElementText(episode, 'Writer'     ) }
 
             ### Check for Missing Summaries ### 
-            if getElementText(episode, 'Overview'):  
-              summary_present.append(numbering)
-            else:
-   	          summary_missing.append(numbering)
+            if getElementText(episode, 'Overview'):  summary_present.append(numbering)
+            else:                                    summary_missing.append(numbering)
 
             ### Check for Missing Episodes ###
             if not (currentSeasonNum in media.seasons and currentEpNum in media.seasons[currentSeasonNum].episodes) and not (currentSeasonNum in media.seasons and currentAbsNum in media.seasons[currentSeasonNum].episodes):

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -302,7 +302,7 @@ class HamaCommonAgent:
             currentSeasonNum = getElementText(episode, 'SeasonNumber')
             currentEpNum     = getElementText(episode, 'EpisodeNumber')
             currentAbsNum    = getElementText(episode, 'absolute_number')
-			
+
             if defaulttvdbseason=="a": numbering = currentAbsNum
             else:                      numbering = "s" + currentSeasonNum + "e" + (currentEpNum if currentSeasonNum == '0' or not metadata.id.startswith("tvdb3-") else currentAbsNum)
             tvdb_table [numbering] = { 'EpisodeName': getElementText(episode, 'EpisodeName'), 'FirstAired':  getElementText(episode, 'FirstAired' ),
@@ -318,8 +318,14 @@ class HamaCommonAgent:
             if not (currentSeasonNum in media.seasons and currentEpNum in media.seasons[currentSeasonNum].episodes) and not (currentSeasonNum in media.seasons and currentAbsNum in media.seasons[currentSeasonNum].episodes):
               tvdb_episode_missing.append(" s" + currentSeasonNum + "e" + currentEpNum )
 
-        if summary_missing:      error_log['TVDB summaries missing'].append(WEB_LINK % (TVDB_SERIE_URL % tvdbid, tvdbid) + " missing summaries: " + str(summary_missing))
-        if tvdb_episode_missing: error_log['Missing episodes'].append(WEB_LINK % (TVDB_SERIE_URL % tvdbid, tvdbid) + " missing episodes: " + str(tvdb_episode_missing))
+        if summary_missing:
+          logEntry = self.createMissingLogEntry("tvdb", WEB_LINK % (TVDB_SERIE_URL % tvdbid, tvdbid), tvdbtitle, "Summaries", summary_missing)
+          error_log['TVDB summaries missing'].append(logEntry)
+
+        if tvdb_episode_missing:
+          logEntry = self.createMissingLogEntry("tvdb", WEB_LINK % (TVDB_SERIE_URL % tvdbid, tvdbid), tvdbtitle, "Episodes", tvdb_episode_missing)
+          error_log['Missing episodes'].append(logEntry)
+
       else:
         Log.Debug("'anime-list tvdbid missing.htm' log added as tvdb serie deleted: '%s', modify in custom mapping file to circumvent but please submit feedback to ScumLee's mapping file using html log link" % (TVDB_HTTP_API_URL % tvdbid))
         error_log['anime-list tvdbid missing'].append(TVDB_HTTP_API_URL % tvdbid + " - xml not downloadable so serie deleted from thetvdb")
@@ -559,7 +565,9 @@ class HamaCommonAgent:
           ## End of "for episode in anime.xpath('episodes/episode'):" ### Episode Specific ###########################################################################################
 
           ### AniDB Missing Episodes ###
-          if len(missing_eps)>0:  error_log['Missing episodes'].append("anidbid: %s, Title: '%s', Missing Episodes: %s" % (metadata.id.split("-")[1].zfill(5), title, missing_eps))
+          if len(missing_eps)>0:
+            logEntry = self.createMissingLogEntry("anidb", WEB_LINK % (ANIDB_SERIE_URL % metadata.id[len("anidb-"):], metadata.id.split("-")[1].zfill(5)), title, "Episodes", missing_eps)
+            error_log['Missing episodes'].append(logEntry)
           convert      = lambda text: int(text) if text.isdigit() else text
           alphanum_key = lambda key:  [ convert(c) for c in re.split('([0-9]+)', key) ]
 
@@ -762,6 +770,10 @@ class HamaCommonAgent:
       if langTitles[index]:  langTitles[len(languages)] = langTitles[index];  break                                               # If title present we're done
     else: langTitles[len(languages)] = langTitles[languages.index('main')]                                     # Fallback on main title
     return langTitles[len(languages)].replace("`", "'").encode("utf-8"), langTitles[languages.index('main')].replace("`", "'").encode("utf-8") #
+
+  ### Create consistently formatted log entries ################################################################################################################################
+  def createMissingLogEntry(self, database, link, title, type, missingArray):
+    return "%sid: %s, Title: '%s', Missing %s: %s" % (database, link, title, type, str(missingArray))
     
 ### Agent declaration ###############################################################################################################################################
 class HamaTVAgent(Agent.TV_Shows, HamaCommonAgent):


### PR DESCRIPTION
When testing the Missing Summaries changes for [Issue #43](https://github.com/ZeroQI/Hama.bundle/issues/43), I thought  '`missing eps:`' in '`TVDB summaries missing.htm`' was confusing (maybe '`missing summaries`', '`episodes without summaries`', etc would be better), but that made me realize I didn't have a '`Missing episodes.htm`' at all. This led to two changes:

- Changed '`missing eps:`' to '`missing summaries:`' in '`TVDB summaries missing.htm`'.
  - This seemed like a small change that made things more clear while sticking to the format of the logs. 
- Added a missing episode check to the TVDB portion of '`Update`' in '`__init__.py`'
  - The missing episode log was only being updated in the section that deals with AniDB mapped shows. I use tvdbX.id files almost exclusively for multi-season shows so the agent never generated the missing episodes file for me. Since files can be numbered with the absolute or season episode number I check for both. Might be able to just check for the season episode number in '`media.seasons[currentSeasonNum]`' but I'd need to test more.    