### PR TITLE
Reformatted logs for missing episodes and missing episode descriptions

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -302,7 +302,7 @@ class HamaCommonAgent:
             currentSeasonNum = getElementText(episode, 'SeasonNumber')
             currentEpNum     = getElementText(episode, 'EpisodeNumber')
             currentAbsNum    = getElementText(episode, 'absolute_number')
-			
+
             if defaulttvdbseason=="a": numbering = currentAbsNum
             else:                      numbering = "s" + currentSeasonNum + "e" + (currentEpNum if currentSeasonNum == '0' or not metadata.id.startswith("tvdb3-") else currentAbsNum)
             tvdb_table [numbering] = { 'EpisodeName': getElementText(episode, 'EpisodeName'), 'FirstAired':  getElementText(episode, 'FirstAired' ),
@@ -318,8 +318,14 @@ class HamaCommonAgent:
             if not (currentSeasonNum in media.seasons and currentEpNum in media.seasons[currentSeasonNum].episodes) and not (currentSeasonNum in media.seasons and currentAbsNum in media.seasons[currentSeasonNum].episodes):
               tvdb_episode_missing.append(" s" + currentSeasonNum + "e" + currentEpNum )
 
-        if summary_missing:      error_log['TVDB summaries missing'].append(WEB_LINK % (TVDB_SERIE_URL % tvdbid, tvdbid) + " missing summaries: " + str(summary_missing))
-        if tvdb_episode_missing: error_log['Missing episodes'].append(WEB_LINK % (TVDB_SERIE_URL % tvdbid, tvdbid) + " missing episodes: " + str(tvdb_episode_missing))
+        if summary_missing:
+          logEntry = self.createMissingLogEntry("tvdb", WEB_LINK % (TVDB_SERIE_URL % tvdbid, tvdbid), tvdbtitle, "Summaries", summary_missing)
+          error_log['TVDB summaries missing'].append(logEntry)
+
+        if tvdb_episode_missing:
+          logEntry = self.createMissingLogEntry("tvdb", WEB_LINK % (TVDB_SERIE_URL % tvdbid, tvdbid), tvdbtitle, "Episodes", tvdb_episode_missing)
+          error_log['Missing episodes'].append(logEntry)
+
       else:
         Log.Debug("'anime-list tvdbid missing.htm' log added as tvdb serie deleted: '%s', modify in custom mapping file to circumvent but please submit feedback to ScumLee's mapping file using html log link" % (TVDB_HTTP_API_URL % tvdbid))
         error_log['anime-list tvdbid missing'].append(TVDB_HTTP_API_URL % tvdbid + " - xml not downloadable so serie deleted from thetvdb")
@@ -559,7 +565,9 @@ class HamaCommonAgent:
           ## End of "for episode in anime.xpath('episodes/episode'):" ### Episode Specific ###########################################################################################
 
           ### AniDB Missing Episodes ###
-          if len(missing_eps)>0:  error_log['Missing episodes'].append("anidbid: %s, Title: '%s', Missing Episodes: %s" % (metadata.id.split("-")[1].zfill(5), title, missing_eps))
+          if len(missing_eps)>0:
+            logEntry = self.createMissingLogEntry("anidb", WEB_LINK % (ANIDB_SERIE_URL % metadata.id[len("anidb-"):], metadata.id.split("-")[1].zfill(5)), title, "Episodes", missing_eps)
+            error_log['Missing episodes'].append(logEntry)
           convert      = lambda text: int(text) if text.isdigit() else text
           alphanum_key = lambda key:  [ convert(c) for c in re.split('([0-9]+)', key) ]
 
@@ -762,6 +770,10 @@ class HamaCommonAgent:
       if langTitles[index]:  langTitles[len(languages)] = langTitles[index];  break                                               # If title present we're done
     else: langTitles[len(languages)] = langTitles[languages.index('main')]                                     # Fallback on main title
     return langTitles[len(languages)].replace("`", "'").encode("utf-8"), langTitles[languages.index('main')].replace("`", "'").encode("utf-8") #
+
+  ### Create consistently formatted log entries ################################################################################################################################
+  def createMissingLogEntry(self, database, link, title, type, missingArray):
+    return "%sid: %s, Title: '%s', Missing %s: %s" % (database, link, title, type, str(missingArray))
     
 ### Agent declaration ###############################################################################################################################################
 class HamaTVAgent(Agent.TV_Shows, HamaCommonAgent):


### PR DESCRIPTION
Updating the missing episode and summary logs to have the new format from [Issue #43](https://github.com/ZeroQI/Hama.bundle/issues/43)

> databaseId: #####, Title: 'Series Title', Missing Item: ['...', '...']

The missing season poster log could also use some updates, but right now it appears to only checking for at least a single poster, not really at least a poster per season. May be a bigger change to update it without breaking anything else.

 