### PR TITLE
Missing Episode and Missing Summary logs updates

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -314,8 +314,8 @@ class HamaCommonAgent:
             if currentSeasonNum and not (currentSeasonNum in media.seasons and currentEpNum in media.seasons[currentSeasonNum].episodes) and not (currentSeasonNum in media.seasons and currentAbsNum in media.seasons[currentSeasonNum].episodes):
               tvdb_episode_missing.append(" s" + currentSeasonNum + "e" + currentEpNum )
 
-        if summary_missing:      error_log['TVDB summaries missing'].append(WEB_LINK % (TVDB_SERIE_URL % tvdbid, tvdbid) + " missing summaries: " + str(summary_missing     ))
-        if tvdb_episode_missing: error_log['Missing episodes'      ].append(WEB_LINK % (TVDB_SERIE_URL % tvdbid, tvdbid) + " missing episodes: "  + str(tvdb_episode_missing))
+        if summary_missing:      error_log['TVDB summaries missing'].append("tvdbid: %s, Title: '%s', Missing Summaries: %s" % (WEB_LINK % (TVDB_SERIE_URL % tvdbid, tvdbid), tvdbtitle, str(summary_missing)))
+        if tvdb_episode_missing: error_log['Missing episodes'      ].append("tvdbid: %s, Title: '%s', Missing Episodes: %s" % (WEB_LINK % (TVDB_SERIE_URL % tvdbid, tvdbid), tvdbtitle, str(tvdb_episode_missing)))
       else:
         Log.Debug("'anime-list tvdbid missing.htm' log added as tvdb serie deleted: '%s', modify in custom mapping file to circumvent but please submit feedback to ScumLee's mapping file using html log link" % (TVDB_HTTP_API_URL % tvdbid))
         error_log['anime-list tvdbid missing'].append(TVDB_HTTP_API_URL % tvdbid + " - xml not downloadable so serie deleted from thetvdb")
@@ -555,7 +555,8 @@ class HamaCommonAgent:
           ## End of "for episode in anime.xpath('episodes/episode'):" ### Episode Specific ###########################################################################################
 
           ### AniDB Missing Episodes ###
-          if len(missing_eps)>0:  error_log['Missing episodes'].append("anidbid: %s, Title: '%s', Missing Episodes: %s" % (metadata.id.split("-")[1].zfill(5), title, missing_eps))
+          if len(missing_eps)>0:  error_log['Missing episodes'].append("anidbid: %s, Title: '%s', Missing Episodes: %s" % (WEB_LINK % (ANIDB_SERIE_URL % metadata.id.split("-")[1], metadata.id.split("-")[1].zfill(5)), title, missing_eps))
+
           convert      = lambda text: int(text) if text.isdigit() else text
           alphanum_key = lambda key:  [ convert(c) for c in re.split('([0-9]+)', key) ]
 


### PR DESCRIPTION
Per the conversation going on in [Issue #43](https://github.com/ZeroQI/Hama.bundle/issues/43), I updated the log entry format and split out Season 0 entries for both the missing episode and summary logs.

Tried to better match the existing code style this time, but let me know if anything is off.