### PR TITLE
Fetch Posters, Banners and Background Art from fanart.tv

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -49,7 +49,7 @@ for handler in hama_logger.handlers:  handler.setFormatter(formatter)
 
 ### Pre-Defined ValidatePrefs function Values in "DefaultPrefs.json", accessible in Settings>Tab:Plex Media Server>Sidebar:Agents>Tab:Movies/TV Shows>Tab:HamaTV #######
 def ValidatePrefs(): #     a = sum(getattr(t, name, 0) for name in "xyz")
-  DefaultPrefs = ("GetTvdbFanart", "GetTvdbPosters", "GetTvdbBanners", "GetAnidbPoster", "GetTmdbFanart", "GetTmdbPoster", "GetOmdbPoster", "GetASSPosters", "localart", "adult", 
+  DefaultPrefs = ("GetTvdbFanart", "GetTvdbPosters", "GetTvdbBanners", "GetAnidbPoster", "GetTmdbFanart", "GetTmdbPoster", "GetOmdbPoster", "GetFanartTVBackground", "GetFanartTVPoster", "GetFanartTVBanner", "GetASSPosters", "localart", "adult", 
                   "GetPlexThemes", "MinimumWeight", "SerieLanguage1", "SerieLanguage2", "SerieLanguage3", "EpisodeLanguage1", "EpisodeLanguage2")
   try:  
     for key in DefaultPrefs: Log.Info("Prefs[%s] = %s" % (key, Prefs[key]))

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -22,7 +22,8 @@ OMDB_HTTP_API_URL            = "http://www.omdbapi.com/?i="                     
 THEME_URL                    = 'http://tvthemes.plexapp.com/%s.mp3'                                                               # Plex TV Theme url
 ASS_MAPPING_URL              = 'http://rawgit.com/ZeroQI/Absolute-Series-Scanner/master/tvdb4.mapping.xml'                        #
 ASS_POSTERS_URL              = 'http://rawgit.com/ZeroQI/Absolute-Series-Scanner/master/tvdb4.posters.xml'                        #
-FANART_TV_URL                = 'http://webservice.fanart.tv/v3/tv/{tvdbid}?api_key={api_key}'                                                  # Fanart TV URL
+FANART_TV_TV_URL             = 'http://webservice.fanart.tv/v3/tv/{tvdbid}?api_key={api_key}'                                     # Fanart TV URL for TV
+FANART_TV_MOVIES_URL         = 'http://webservice.fanart.tv/v3/movies/{tvdbid}?api_key={api_key}'                                 # Fanart TV URL for Movies
 FANART_TV_API_KEY            = 'a270e3b8562048563dc03e623913ffd3'                                                                 # API key for Hama Dev
 RESTRICTED_GENRE             = {'X': ["18 restricted", "pornography"], 'TV-MA': ["tv censoring", "borderline porn"]}
 MOVIE_RATING_MAP             = {'TV-Y': 'G', 'TV-Y7': 'G', 'TV-G': 'G', 'TV-PG': 'PG', 'TV-14': 'PG-13', 'TV-MA': 'NC-17', 'X': 'X'}
@@ -794,9 +795,9 @@ class HamaCommonAgent:
   def getImagesFromFanartTV(self, metadata, tvdbid, num=100):
     Log.Info("Fetching from fanart.tv")
     try:
-      FanartTV = self.get_json(FANART_TV_URL.format(tvdbid=tvdbid, api_key=FANART_TV_API_KEY))
+      FanartTV = self.get_json(FANART_TV_TV_URL.format(tvdbid=tvdbid, api_key=FANART_TV_API_KEY))
     except Exception as e:
-      Log.Error("Exception - FanartTV - tvdbid: '{tvdbid}', url: '{url}', Exception: '{exception}'".format(tvdbid=tvdbid, url=FANART_TV_URL.format(tvdbid=tvdbid, api_key=FANART_TV_API_KEY), exception=e))
+      Log.Error("Exception - FanartTV - tvdbid: '{tvdbid}', url: '{url}', Exception: '{exception}'".format(tvdbid=tvdbid, url=FANART_TV_TV_URL.format(tvdbid=tvdbid, api_key=FANART_TV_API_KEY), exception=e))
     else:
       if FanartTV and 'showbackground' in FanartTV and Prefs['GetFanartTVBackground']:
         Log.Debug("fanart.tv has {count} background images/art".format(count=len(FanartTV['showbackground'])))

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -329,7 +329,6 @@ class HamaCommonAgent:
         if tvdbposternumber == 0:  error_log['TVDB posters missing'].append("tvdbid: %s | Title: '%s'" % (WEB_LINK % (TVDB_SERIE_URL % tvdbid, tvdbid), tvdbtitle))
         if tvdbseasonposter == 0:  error_log['TVDB season posters missing'].append("tvdbid: %s | Title: '%s'" % (WEB_LINK % (TVDB_SERIE_URL % tvdbid, tvdbid), tvdbtitle))
         if tvdbposternumber * tvdbseasonposter == 0:  Log.Warn("TVDB - No poster, check logs in ../../Plug-in Support/Data/com.plexapp.agents.hama/DataItems/TVDB posters missing.htm to update Metadata Source")
-        self.getImagesFromFanartTV(metadata, tvdbid)
 
     ### Movie posters including imdb from TVDB ###
     if Prefs["GetTmdbFanart"] or Prefs["GetTmdbPoster"]:
@@ -338,6 +337,10 @@ class HamaCommonAgent:
     
     ### Movie posters including imdb from OMDB ###
     if Prefs["GetOmdbPoster"] and imdbid.isalnum(): self.getImagesFromOMDB(metadata, imdbid, 98)  #return 200 but not downloaded correctly - IMDB has a single poster, downloading through OMDB xml, prefered by mapping file
+    
+    ### fanart.tv - Background, Poster and Banner ##
+    if Prefs['GetFanartTVBackground'] or Prefs['GetFanartTVPoster'] or Prefs['GetFanartTVBanner']:
+        self.getImagesFromFanartTV(metadata, tvdbid)
     
     ### TVDB mode when a season 2 or more exist ############################################################################################################
     if not movie and (len(media.seasons)>2 or max(map(int, media.seasons.keys()))>1 or metadata_id_source_core == "tvdb"):
@@ -795,19 +798,19 @@ class HamaCommonAgent:
     except Exception as e:
       Log.Error("Exception - FanartTV - tvdbid: '{tvdbid}', url: '{url}', Exception: '{exception}'".format(tvdbid=tvdbid, url=FANART_TV_URL.format(tvdbid=tvdbid, api_key=FANART_TV_API_KEY), exception=e))
     else:
-      if FanartTV and 'showbackground' in FanartTV:
+      if FanartTV and 'showbackground' in FanartTV and Prefs['GetFanartTVBackground']:
         Log.Debug("fanart.tv has {count} background images/art".format(count=len(FanartTV['showbackground'])))
         for art in FanartTV['showbackground']:
           self.metadata_download(metadata.art, art['url'], num, "FanartTV/{filename}.jpg".format(filename=art['id']))
-      if FanartTV and 'tvposter' in FanartTV:
+      if FanartTV and 'tvposter' in FanartTV and Prefs['GetFanartTVPoster']:
         Log.Debug("fanart.tv has {count} series posters".format(count=len(FanartTV['tvposter'])))
         for tvposter in FanartTV['tvposter']:
           self.metadata_download(metadata.posters, tvposter['url'], num, "FanartTV/{filename}.jpg".format(filename=tvposter['id']))
-      if FanartTV and 'seasonposter' in FanartTV:
+      if FanartTV and 'seasonposter' in FanartTV and Prefs['GetFanartTVPoster']:
         Log.Debug("fanart.tv has {count} season posters".format(count=len(FanartTV['seasonposter'])))
         for seasonposter in FanartTV['seasonposter']:
           self.metadata_download(metadata.posters, seasonposter['url'], num, "FanartTV/{filename}.jpg".format(filename=seasonposter['id']))
-      if FanartTV and 'tvbanner' in FanartTV:
+      if FanartTV and 'tvbanner' in FanartTV and Prefs['GetFanartTVBanner']:
         Log.Debug("fanart.tv has {count} banners".format(count=len(FanartTV['tvbanner'])))
         for tvbanner in FanartTV['tvbanner']:
           self.metadata_download(metadata.banners, tvbanner['url'], num, "FanartTV/{filename}.jpg".format(filename=tvbanner['id']))

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -362,7 +362,7 @@ class HamaCommonAgent:
             self.getImagesFromFanartTV(metadata, tmdbid=tmdbid)
         else:
           Log.Debug("It's a series")
-          self.getImagesFromFanartTV(metadata, tvdbid=tvdbid)
+          self.getImagesFromFanartTV(metadata, tvdbid=tvdbid, season=defaulttvdbseason)
     
     ### TVDB mode when a season 2 or more exist ############################################################################################################
     if not movie and (len(media.seasons)>2 or max(map(int, media.seasons.keys()))>1 or metadata_id_source_core == "tvdb"):
@@ -813,7 +813,7 @@ class HamaCommonAgent:
       else:                                                                      Log.Info("No poster to download - " + OMDB_HTTP_API_URL + imdbid)
   
   ### Fetch extra images from fanart.tv ###################################################################################################################
-  def getImagesFromFanartTV(self, metadata, tvdbid=None, tmdbid=None, num=100):
+  def getImagesFromFanartTV(self, metadata, tvdbid=None, tmdbid=None, season=0, num=100):
     Log.Info("Fetching from fanart.tv")
     if tvdbid:
       try:
@@ -833,6 +833,15 @@ class HamaCommonAgent:
         Log.Debug("fanart.tv has {count} season posters".format(count=len(FanartTV['seasonposter'])))
         for seasonposter in FanartTV['seasonposter']:
           self.metadata_download(metadata.posters, seasonposter['url'], num, "FanartTV/series-{filename}.jpg".format(filename=seasonposter['id']))
+          if seasonposter['season'] == 0:
+            # Special
+            self.metadata_download(metadata.seasons[0].posters, seasonposter['url'], num, "FanartTV/series-{filename}.jpg".format(filename=seasonposter['id']))
+          else:
+            # Non-special. Add any posters to "Season 1" entry if they match this 'actual' season.
+            if seasonposter['season'] == season:
+              self.metadata_download(metadata.seasons[1].posters, seasonposter['url'], num, "FanartTV/series-{filename}.jpg".format(filename=seasonposter['id']))
+            else:
+              pass
       if FanartTV and 'tvbanner' in FanartTV and Prefs['GetFanartTVBanner']:
         Log.Debug("fanart.tv has {count} banners".format(count=len(FanartTV['tvbanner'])))
         for tvbanner in FanartTV['tvbanner']:

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -851,10 +851,6 @@ class HamaCommonAgent:
         Log.Debug("fanart.tv has {count} movie posters".format(count=len(FanartTV['movieposter'])))
         for movieposter in FanartTV['movieposter']:
           self.metadata_download(metadata.posters, movieposter['url'], num, "FanartTV/movie-{filename}.jpg".format(filename=movieposter['id']))
-      if FanartTV and 'moviebanner' in FanartTV and Prefs['GetFanartTVBanner']:
-        Log.Debug("fanart.tv has {count} movie banners".format(count=len(FanartTV['moviebanner'])))
-        for moviebanner in FanartTV['moviebanner']:
-          self.metadata_download(metadata.banners, moviebanner['url'], num, "FanartTV/movie-{filename}.jpg".format(filename=moviebanner['id']))
 
   #########################################################################################################################################################
   def metadata_download (self, metatype, url, num=99, filename="", url_thumbnail=None):  #if url in metatype:#  Log.Debug("url: '%s', num: '%s', filename: '%s'*" % (url, str(num), filename)) # Log.Debug(str(metatype))   #  return

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -824,37 +824,37 @@ class HamaCommonAgent:
       if FanartTV and 'showbackground' in FanartTV and Prefs['GetFanartTVBackground']:
         Log.Debug("fanart.tv has {count} background images/art".format(count=len(FanartTV['showbackground'])))
         for art in FanartTV['showbackground']:
-          self.metadata_download(metadata.art, art['url'], num, "FanartTV/{filename}.jpg".format(filename=art['id']))
+          self.metadata_download(metadata.art, art['url'], num, "FanartTV/series-{filename}.jpg".format(filename=art['id']))
       if FanartTV and 'tvposter' in FanartTV and Prefs['GetFanartTVPoster']:
         Log.Debug("fanart.tv has {count} series posters".format(count=len(FanartTV['tvposter'])))
         for tvposter in FanartTV['tvposter']:
-          self.metadata_download(metadata.posters, tvposter['url'], num, "FanartTV/{filename}.jpg".format(filename=tvposter['id']))
+          self.metadata_download(metadata.posters, tvposter['url'], num, "FanartTV/series-{filename}.jpg".format(filename=tvposter['id']))
       if FanartTV and 'seasonposter' in FanartTV and Prefs['GetFanartTVPoster']:
         Log.Debug("fanart.tv has {count} season posters".format(count=len(FanartTV['seasonposter'])))
         for seasonposter in FanartTV['seasonposter']:
-          self.metadata_download(metadata.posters, seasonposter['url'], num, "FanartTV/{filename}.jpg".format(filename=seasonposter['id']))
+          self.metadata_download(metadata.posters, seasonposter['url'], num, "FanartTV/series-{filename}.jpg".format(filename=seasonposter['id']))
       if FanartTV and 'tvbanner' in FanartTV and Prefs['GetFanartTVBanner']:
         Log.Debug("fanart.tv has {count} banners".format(count=len(FanartTV['tvbanner'])))
         for tvbanner in FanartTV['tvbanner']:
-          self.metadata_download(metadata.banners, tvbanner['url'], num, "FanartTV/{filename}.jpg".format(filename=tvbanner['id']))
+          self.metadata_download(metadata.banners, tvbanner['url'], num, "FanartTV/series-{filename}.jpg".format(filename=tvbanner['id']))
     elif tmdbid:
       try:
         Log.Debug("Is a movie")
         FanartTV = self.get_json(FANART_TV_MOVIES_URL.format(tmdbid=tmdbid, api_key=FANART_TV_API_KEY))
       except Exception as e:
-        Log.Error("Exception - FanartTV - tmdbid: '{tmdbid}', url: '{url}', Exception: '{exception}'".format(tmdbid=tmdbid, url=FANART_TV_MOVIES_URL.format(tmdbid=tmdbid, api_key=FANART_TV_API_KEY), exception=e))
+        Log.Error("Exception - FanartTV - tmdbid: '{tmdbid}', url: '{url}', Exception: 'movie-{exception}'".format(tmdbid=tmdbid, url=FANART_TV_MOVIES_URL.format(tmdbid=tmdbid, api_key=FANART_TV_API_KEY), exception=e))
       if FanartTV and 'moviebackground' in FanartTV and Prefs['GetFanartTVBackground']:
         Log.Debug("fanart.tv has {count} movie background images/art".format(count=len(FanartTV['moviebackground'])))
         for art in FanartTV['moviebackground']:
-          self.metadata_download(metadata.art, art['url'], num, "FanartTV/{filename}.jpg".format(filename=art['id']))
+          self.metadata_download(metadata.art, art['url'], num, "FanartTV/movie-{filename}.jpg".format(filename=art['id']))
       if FanartTV and 'movieposter' in FanartTV and Prefs['GetFanartTVPoster']:
         Log.Debug("fanart.tv has {count} movie posters".format(count=len(FanartTV['movieposter'])))
         for movieposter in FanartTV['movieposter']:
-          self.metadata_download(metadata.posters, movieposter['url'], num, "FanartTV/{filename}.jpg".format(filename=movieposter['id']))
+          self.metadata_download(metadata.posters, movieposter['url'], num, "FanartTV/movie-{filename}.jpg".format(filename=movieposter['id']))
       if FanartTV and 'moviebanner' in FanartTV and Prefs['GetFanartTVBanner']:
         Log.Debug("fanart.tv has {count} movie banners".format(count=len(FanartTV['moviebanner'])))
         for moviebanner in FanartTV['moviebanner']:
-          self.metadata_download(metadata.banners, moviebanner['url'], num, "FanartTV/{filename}.jpg".format(filename=moviebanner['id']))
+          self.metadata_download(metadata.banners, moviebanner['url'], num, "FanartTV/movie-{filename}.jpg".format(filename=moviebanner['id']))
 
   #########################################################################################################################################################
   def metadata_download (self, metatype, url, num=99, filename="", url_thumbnail=None):  #if url in metatype:#  Log.Debug("url: '%s', num: '%s', filename: '%s'*" % (url, str(num), filename)) # Log.Debug(str(metatype))   #  return

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -42,6 +42,24 @@
     "default" : "false"
   },
   {
+    "id"      : "GetFanartTVBackground",
+    "label"   : "Fetch background images from fanart.tv",
+    "type"    : "bool",
+    "default" : "false"
+  },
+  {
+    "id"      : "GetFanartTVPoster",
+    "label"   : "Fetch poster images from fanart.tv",
+    "type"    : "bool",
+    "default" : "false"
+  },
+  {
+    "id"      : "GetFanartTVBanner",
+    "label"   : "Fetch banner images from fanart.tv",
+    "type"    : "bool",
+    "default" : "false"
+  },
+  {
     "id"      : "GetASSPosters",
     "label"   : "Fetch poster images from ASS tvdb4 urls",
     "type"    : "bool",


### PR DESCRIPTION
Although fanart.tv isn't always as comprehensive as the TVDB for Posters, Banners and Background Art, all of the ones it has tend to be of very high quality and are often unique.  This pull request adds support to Hama for downloading these images from fanart.tv and loading them in to Plex. Development was done against the latest trunk version of Hama, and tested with the latest Absolute Series Scanner and Plex Media Server version 1.1.2.2680. Here's what's working at the moment;

- Posters, Banners and Background Art for shows, based off their TVDB ID.
- Season Posters for Seasons
- Posters and Background Art for movies, based off their TMDB ID. If a movie is missing a TMDB identifier in the master anime list but the IMDB ID is present, it will query TMDB using the IMDB ID to get the TMDB ID.
- New options have been added in the agent settings to control the download of Posters/Banners/Background Art. As with the other artwork fetch options, i've set the ones for fanart.tv to be disabled by default.

As for what's not working/any caveats;
- A new folder (FanartTV) needs to be created in the DataItems folder so that the images can be saved locally. This is not currently present in Plug-in.Support.folders.zip, so unless the folder is manually created the images won't download.
- For the main show entry, Posters and Season Posters will be downloaded (I chose to do this as when AniDB splits seasons, it's nice to be able to still have "Season 1" etc as the poster on the main entry in Plex).
- For the "Specials" season, any Specials seasons posters should be downloaded **but this is untested** as I couldn't find any entries on fanart.tv that had a Season 0 seasonposter and were also in my collection!
- When the AniDB show entry is a TVDB season other than Season 1, the "Season 1" posters in that entry should be those of the actual season. E.G. For a show on AniDB that is listed as Season 2 on TVDB, the "Season 1" posters would include those that are listed as Season 2 on fanart.tv. This mostly works **but not in all cases**. The one case I found that doesn't work is where a show has two AniDB entries but only one TVDB entry and someone has uploaded it as split-seasons on fanart.tv  (e.g. Fate/Stay Night: Unlimited Blade Works has a 2014 and 2015 entry on AniDB, but is listed as a single season on TVDB. On fanart.tv, someone has uploaded seperate Season 1 and 2 banners). I'm not sure how best to solve this, but it seems like an edge case really - I think most of the time we should be trusting the TVDB season when querying fanart.tv.
- The API key used for fanart.tv is currently registered to my account under the name "Hama Dev". If you merge this PR, you might want to register a new application API key for Hama 'Prod'. fanart.tv also supports [personal API keys](https://fanart.tv/2015/01/personal-api-keys/) in addition to application API keys. A personal API key lets a user gain access to newly uploaded artwork 2 days after upload, instead of 1 week after upload (VIPs can also use a personal API key to gain access to newly uploaded artwork immediately). I haven't implemented support for personal API keys, but it's on my todo list.
- I have only tested it in anidb mode, testing with the various tvdb modes hasn't been tested and I have no idea what will happen if these modes are used! At a guess, the Posters, Banners and Background Art for the show should download correctly but the art for each season probably won't as they've been hardcoded to season 0/1 as appropriate.
- I'm not sure if caching is always working correctly - in the logs I occasionally see a Not Caching message with the reason `content type 'image/jpeg' not cacheable in Agent plug-ins`.

I think that covers everything. This is my first ever serious pull request so please let me know if i've done anything wrong! I welcome any feedback on the code itself, i've tried to keep it clean, readable and commented as appropriate. Even though fanart.tv might not have the greatest selection of extra artwork, it'd be great to have this in Hama so we've got even more artwork to choose from! :smile: 