### PR TITLE
Add Actor Metadata for Movies

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -531,6 +531,23 @@ class HamaCommonAgent:
         if metadata.studio == "" and mapping_studio:                                 metadata.studio = mapping_studio
         Log.Info(log_string)
 
+        ### AniDB Cast ###
+        if movie:
+          metadata.roles.clear()
+          # Get all the voice actors that voice main or secondary characters.
+          for character in anime.xpath("characters/character[(@type='secondary cast in') or (@type='main character in')]"):
+            try:
+              character_name = character.find('name').text
+              seiyuu = character.find('seiyuu')
+              seiyuu_picture_url = ANIDB_PIC_BASE_URL + seiyuu.get('picture')
+              seiyuu_name = seiyuu.text
+              Log.Debug("{seiyuu} voices {character} and has a profile picture at {url}".format(seiyuu=seiyuu_name, character=character_name, url=seiyuu_picture_url))
+              role = metadata.roles.new()
+              role.name = seiyuu_name
+              role.role = character_name
+              role.photo = seiyuu_picture_url
+            except Exception as e:  Log.Error("Could not locate Seiyuu information for character ID {id}, Exception: {exception}".format(id=character.get('id'), exception=e))
+
         ### AniDB Serie/Movie description ###
         try:                    description = re.sub(r'http://anidb\.net/[a-z]{1,2}[0-9]+ \[(.+?)\]', r'\1', getElementText(anime, 'description')).replace("`", "'") # Remove wiki-style links to staff, characters etc
         except Exception as e:  description = ""; Log.Error("Exception: %s" % e)

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -531,21 +531,16 @@ class HamaCommonAgent:
         if metadata.studio == "" and mapping_studio:                                 metadata.studio = mapping_studio
         Log.Info(log_string)
 
-        ### AniDB Cast ###
+        ### AniDB Cast - Get all the voice actors that voice main or secondary characters ###
         if movie:
           metadata.roles.clear()
-          # Get all the voice actors that voice main or secondary characters.
           for character in anime.xpath("characters/character[(@type='secondary cast in') or (@type='main character in')]"):
             try:
-              character_name = character.find('name').text
-              seiyuu = character.find('seiyuu')
-              seiyuu_picture_url = ANIDB_PIC_BASE_URL + seiyuu.get('picture')
-              seiyuu_name = seiyuu.text
+              seiyuu,      character_name     = character.find('seiyuu'), character.find('name').text
+              seiyuu_name, seiyuu_picture_url = seiyuu.text, ANIDB_PIC_BASE_URL + seiyuu.get('picture')
               Log.Debug("{seiyuu} voices {character} and has a profile picture at {url}".format(seiyuu=seiyuu_name, character=character_name, url=seiyuu_picture_url))
-              role = metadata.roles.new()
-              role.name = seiyuu_name
-              role.role = character_name
-              role.photo = seiyuu_picture_url
+              role                             = metadata.roles.new()
+              role.name, role.role, role.photo = seiyuu_name, character_name, seiyuu_picture_url
             except Exception as e:  Log.Error("Could not locate Seiyuu information for character ID {id}, Exception: {exception}".format(id=character.get('id'), exception=e))
 
         ### AniDB Serie/Movie description ###


### PR DESCRIPTION
This PR allows Hama to add seiyuu/voice actor information to Plex's "cast" metadata for movies. Only main and secondary characters are included to keep the list to a reasonable size. Voice actor roles and pictures are also included. The pictures are not downloaded to Hama's Plug-in Support folder as Plex's role object helpfully downloads and saves the image when creating that voice actor for the first time only.

I'll look at extending this to series as well, but it's a little more complicated.

Here's a little preview of what happens now if you search for a voice actor's name in Plex Web. You get the movie(s) they're in, along with the voice actor themselves and their picture. Clicking the voice actor takes you to a filtered list of all movies that actor is in.

![image](https://cloud.githubusercontent.com/assets/6966796/20870228/58883930-ba7c-11e6-8d63-145b05a3d3f3.png)
