### PR TITLE
Add actors to Series

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -532,16 +532,15 @@ class HamaCommonAgent:
         Log.Info(log_string)
 
         ### AniDB Cast - Get all the voice actors that voice main or secondary characters ###
-        if movie:
-          metadata.roles.clear()
-          for character in anime.xpath("characters/character[(@type='secondary cast in') or (@type='main character in')]"):
-            try:
-              seiyuu,      character_name     = character.find('seiyuu'), character.find('name').text
-              seiyuu_name, seiyuu_picture_url = seiyuu.text, ANIDB_PIC_BASE_URL + seiyuu.get('picture')
-              Log.Debug("{seiyuu} voices {character} and has a profile picture at {url}".format(seiyuu=seiyuu_name, character=character_name, url=seiyuu_picture_url))
-              role                             = metadata.roles.new()
-              role.name, role.role, role.photo = seiyuu_name, character_name, seiyuu_picture_url
-            except Exception as e:  Log.Error("Could not locate Seiyuu information for character ID {id}, Exception: {exception}".format(id=character.get('id'), exception=e))
+        metadata.roles.clear()
+        for character in anime.xpath("characters/character[(@type='secondary cast in') or (@type='main character in')]"):
+          try:
+            seiyuu,      character_name     = character.find('seiyuu'), character.find('name').text
+            seiyuu_name, seiyuu_picture_url = seiyuu.text, ANIDB_PIC_BASE_URL + seiyuu.get('picture')
+            Log.Debug("{seiyuu} voices {character} and has a profile picture at {url}".format(seiyuu=seiyuu_name, character=character_name, url=seiyuu_picture_url))
+            role                             = metadata.roles.new()
+            role.name, role.role, role.photo = seiyuu_name, character_name, seiyuu_picture_url
+          except Exception as e:  Log.Error("Could not locate Seiyuu information for character ID {id}, Exception: {exception}".format(id=character.get('id'), exception=e))
 
         ### AniDB Serie/Movie description ###
         try:                    description = re.sub(r'http://anidb\.net/[a-z]{1,2}[0-9]+ \[(.+?)\]', r'\1', getElementText(anime, 'description')).replace("`", "'") # Remove wiki-style links to staff, characters etc


### PR DESCRIPTION
Fixes #95.

This was actually stupidly simple in the end. Whilst developing #94 yesterday, I didn't have the `if movie:` condition on the code block at first. However, I couldn't see the actor information on any series that I refreshed and naively assumed that I needed to add them in a different manner and limited my #94 PR to be for just movies. However, it turns out that this is the correct method for adding them, but that Plex Web doesn't show actors on the TV series information page like it does on the movie information page. They do however show up in searches and on the raw XML page. Other Plex clients might expose them in the TV series information page but I haven't found any that do yet.

Here's an example of what search looks like now when an actor is present in multiple libraries;

![image](https://cloud.githubusercontent.com/assets/6966796/20906431/ee808a14-bb3f-11e6-9e20-8d3a477d1944.png)



