### PR TITLE
Prevent execution of series-specific TVDB code when scanning movies.

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -267,7 +267,7 @@ class HamaCommonAgent:
     
     ### TVDB ID exists ####
     tvdbtitle, tvdbOverview, tvdbFirstAired, tvdbContentRating, tvdbNetwork, tvdbGenre = "", "", "", "", "", []
-    if tvdbid.isdigit():
+    if not movie and tvdbid.isdigit():
 
       ### Plex - Plex Theme song - https://plexapp.zendesk.com/hc/en-us/articles/201178657-Current-TV-Themes ###
       if THEME_URL % tvdbid in metadata.themes:  Log.Info("Theme song - already added")

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -267,7 +267,7 @@ class HamaCommonAgent:
     
     ### TVDB ID exists ####
     tvdbtitle, tvdbOverview, tvdbFirstAired, tvdbContentRating, tvdbNetwork, tvdbGenre = "", "", "", "", "", []
-    if not movie and tvdbid.isdigit():
+    if tvdbid.isdigit():
 
       ### Plex - Plex Theme song - https://plexapp.zendesk.com/hc/en-us/articles/201178657-Current-TV-Themes ###
       if THEME_URL % tvdbid in metadata.themes:  Log.Info("Theme song - already added")
@@ -292,7 +292,7 @@ class HamaCommonAgent:
       
         ### TVDB - Build 'tvdb_table' ###
         abs_manual_placement_worked = True
-        if defaulttvdbseason != "0" and max(map(int, media.seasons.keys()))==1 or metadata_id_source in ["tvdb3", "tvdb4"]:
+        if not movie and defaulttvdbseason != "0" and max(map(int, media.seasons.keys()))==1 or metadata_id_source in ["tvdb3", "tvdb4"]:
           ep_count, abs_manual_placement_info, number_set = 0, [], False
           for episode in tvdbanime.xpath('Episode'):
             if episode.xpath('SeasonNumber')[0].text != '0':


### PR DESCRIPTION
Only run the TVDB metadata fetching code if we're not in movie-mode. Fixes #99.

The only issue with this is that it if there is a valid entry on TVDB for this movie (which does happen sometimes - if there's a series that also has a related movie, it'll often be in the specials), then no covers/backgrounds etc will be downloaded. We can fix this by wrapping [these lines](https://github.com/ZeroQI/Hama.bundle/blob/f269e870606825452afae0145943ab5ea3461148/Contents/Code/__init__.py#L360-L365) in an "if tvdbid.isdigit()" block, and the rest in a subsequent "is movie" block. This is a quick fix for now though that prevents movie scanning from crash.