### PR TITLE
Fix Director/Writer Metadata for Series

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -412,12 +412,14 @@ class HamaCommonAgent:
             if 'filename'    in tvdb_table[ep] and tvdb_table [ep] ['filename'] and tvdb_table [ep] ['filename'] != "":  self.metadata_download (metadata.seasons[media_season].episodes[media_episode].thumbs, TVDB_IMAGES_URL + tvdb_table[ep]['filename'], 1, "TVDB/episodes/"+ os.path.basename(tvdb_table[ep]['filename']))
             if 'Director'    in tvdb_table[ep] and tvdb_table [ep] ['Director']:
               for this_director in re.split(',|\|', tvdb_table[ep]['Director']):
-                if this_director not in metadata.seasons[media_season].episodes[media_episode].directors:
-                  metadata.seasons[media_season].episodes[media_episode].directors.add(this_director)
+                meta_director = metadata.seasons[media_season].episodes[media_episode].directors.new()
+                Log.Debug("Adding new Director {name}".format(name=this_director))
+                meta_director.name = this_director
             if 'Writer'      in tvdb_table[ep] and tvdb_table [ep] ['Writer']:
               for this_writer in re.split(',|\|', tvdb_table[ep]['Writer']):
-                if this_writer not in metadata.seasons[media_season].episodes[media_episode].writers:
-                  metadata.seasons[media_season].episodes[media_episode].writers.add(this_writer)
+                meta_writer = metadata.seasons[media_season].episodes[media_episode].writers.new()
+                Log.Debug("Adding new Writer {name}".format(name=this_writer))
+                meta_writer.name = this_writer
             if 'Rating'      in tvdb_table[ep] and tvdb_table [ep] ['Rating']:
               try:                    metadata.seasons[media_season].episodes[media_episode].rating  = float(tvdb_table [ep] ['Rating'])
               except Exception as e:  Log.Error("float issue: '%s', Exception: '%s'" % (tvdb_table [ep] ['Rating'], e)) #ValueError

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -601,14 +601,20 @@ class HamaCommonAgent:
               if season == "1": numEpisodes, totalDuration = numEpisodes + 1, totalDuration + episodeObj.duration
             
             ### AniDB Writers, Producers, Directors ###  #Log.Debug("### AniDB Writers, Producers, Directors ### ")
+            Log.Info("Processing writers and directors for Episode.")
             episodeObj.writers.clear()
-            episodeObj.producers.clear()
             episodeObj.directors.clear()
             for role in plex_role:
               for person in plex_role[role]:
-                if role=="writers"   and person not in episodeObj.writers:   episodeObj.writers.add  (person)
-                if role=="producers" and person not in episodeObj.producers: episodeObj.producers.add(person)
-                if role=="directors" and person not in episodeObj.directors: episodeObj.directors.add(person)
+                # Note: Writer/Director metadata is only written when the show is refreshed, not the episode.
+                if role=="writers":
+                  meta_writer = episodeObj.writers.new()
+                  Log.Debug("Adding new Writer {name}".format(name=person))
+                  meta_writer.name = person
+                if role=="directors":
+                  meta_director = episodeObj.directors.new()
+                  Log.Debug("Adding new Director {name}".format(name=person))
+                  meta_director.name = person
             
             ### Rating ###
             rating = getElementText(episode, 'rating') #if rating =="":  Log.Debug(metadata.id + " Episode rating: ''") #elif rating == episodeObj.rating:  Log.Debug(metadata.id + " update - Episode rating: '%s'*" % rating )


### PR DESCRIPTION
Continuing from #94, this adds Director/Writer metadata for series episodes as well to help fix #89. 

Although this should also work in tvdb2/3/4 modes, i've not been able to test it as I don't have any series in this format. I did try a few from the test library, but they seem to be missing Director/Writer metadata on TVDB. @ZeroQI could I ask you to test it in tvdb2/3/4 mode before merging?

I've only updated the existing code, but from what I can understand different metadata sources are used for the tvdb2/3/4 mode versus standard mode - in tvdb2/3/4 mode the existing code sourced the metadata from the tvdb_table but for standard mode it is sourced from plex_role (AniDB). I've not changed that behaviour when fixing this, but IMO we should be consistent as to where we source this metadata from. For series, I think TVDB is the best place for it as they have per-episode whereas AniDB only has it per-series - if there's e.g. different directors for each episode, AniDB sourced data will put every director on each episode rather than the director who directed that episode. I'll open up a new issue to discuss this.

I had a fun time testing this - it seems that if you refresh the metadata for an individual episode, operations on Directors and Writers, including clearing and adding new ones, are not applied. You have to refresh the entire series for this metadata to be changed.