### PR TITLE
Fix Movie Scanning Errors

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -259,7 +259,7 @@ class HamaCommonAgent:
     
     ### Set TMDB ID for Movies if Missing ###
     if movie and not tmdbid:
-      try:                   tmdbid = self.get_json(TMDB_SEARCH_URL_BY_IMDBID %(imdbid.split(",")[0] if ',' in imdbid else imdbid), cache_time=CACHE_1WEEK * 2)['movie_results'][0]['id']
+      try:                   tmdbid = str(self.get_json(TMDB_SEARCH_URL_BY_IMDBID %(imdbid.split(",")[0] if ',' in imdbid else imdbid), cache_time=CACHE_1WEEK * 2)['movie_results'][0]['id'])
       except Exception as e: Log.Error("get_json - Error fetching JSON page '%s', Exception: '%s'" %(TMDB_SEARCH_URL_BY_IMDBID % (imdbid.split(",")[0] if ',' in imdbid else imdbid), e))
       else:                  Log.Info ("TMDB ID found for IMBD ID {imdbid}. tmdbid: '{tmdbid}'".format(imdbid=(imdbid.split(",")[0] if ',' in imdbid else imdbid), tmdbid=tmdbid))
         


### PR DESCRIPTION
Fixes issue #107. Commit a02c9a9cfe93e77b7dfc00ba15b0715c35102511 treats the tmdbid object as a string (e.g. using the string split method), but the tmdbid is stored as an int. Casting it to a string when first fetching the tmdbid is a quick fix.

I don't think there's any situation where the imdbid -> tmdbid lookup would return multiple tmdbids (and thus need splitting), but treating the tmdbid as a string keeps the code consistent with code that uses the imdbid.