### PR TITLE
TheTVDB GetMetadata breaks unless localart is true

### DIFF
--- a/Contents/Code/TheTVDB.py
+++ b/Contents/Code/TheTVDB.py
@@ -140,8 +140,8 @@ def GetMetadata(media, movie, error_log, lang, metadata_source, AniDBid, TVDBid,
         
       ### Rank ###
       rank = 1 if bannerType=='poster' and anidb_offset == divmod(count_valid['poster'], poster_total)[1] else count_valid[bannerType]+2
+      language = GetXml(banner, 'Language')
       if Prefs['localart']:
-        language          = GetXml(banner, 'Language')
         language_priority = [item.strip() for item in Prefs['EpisodeLanguagePriority'].split(',')]
         rank += 10*language_priority.index(language) if language and language in language_priority else 50
       if bannerType in ('poster', 'season'):  Log.Info("[!] bannerType: {}, season: {:>2}, rank: {:>3}, language: {:>2}, filename: {}".format(bannerType, season, rank, language, GetXml(banner, 'BannerPath')))


### PR DESCRIPTION
language was only initialized if "Prefer Language artwork" was checked in the settings
Then the whole metadata update broke when logging info about the banner