### PR TITLE
Updated download method to Invoke-Webrequest

### DIFF
--- a/PowerShell Update Agent.ps1
+++ b/PowerShell Update Agent.ps1
@@ -1,5 +1,5 @@
 #Download files
-(New-Object System.Net.WebClient).DownloadFile("https://raw.githubusercontent.com/ZeroQI/Hama.bundle/master/README.md", "README.md")
-(New-Object System.Net.WebClient).DownloadFile("https://raw.githubusercontent.com/ZeroQI/Hama.bundle/master/Contents/Info.plist", "Contents/Info.plist")
-(New-Object System.Net.WebClient).DownloadFile("https://raw.githubusercontent.com/ZeroQI/Hama.bundle/master/Contents/DefaultPrefs.json", "Contents/DefaultPrefs.json")
-(New-Object System.Net.WebClient).DownloadFile("https://raw.githubusercontent.com/ZeroQI/Hama.bundle/master/Contents/Code/__init__.py" , "Contents/Code/__init__.py" )
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/ZeroQI/Hama.bundle/master/README.md" -OutFile "README.md"
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/ZeroQI/Hama.bundle/master/Contents/Info.plist" -OutFile "Contents/Info.plist"
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/ZeroQI/Hama.bundle/master/Contents/DefaultPrefs.json"-OutFile "Contents/DefaultPrefs.json"
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/ZeroQI/Hama.bundle/master/Contents/Code/__init__.py" -OutFile "Contents/Code/__init__.py" 


### PR DESCRIPTION
Updated to Invoke-Webrequest cause downloads with (New-Object System.Net.WebClient).DownloadFile() always fail with
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], MethodInvocationException
    + FullyQualifiedErrorId : WebException