### PR TITLE
Handle AdjustMapping gracefully when incomplete data from AniDB ban

### DIFF
--- a/Contents/Code/AniDB.py
+++ b/Contents/Code/AniDB.py
@@ -133,6 +133,7 @@ def GetMetadata(media, movie, error_log, source, AniDBid, TVDBid, AniDBMovieSets
     xml = common.LoadFile(filename=AniDBid+".xml", relativeDirectory=os.path.join("AniDB", "xml"), url=ANIDB_HTTP_API_URL+AniDBid)  # AniDB title database loaded once every 2 weeks
 
     if not xml:
+      SaveDict(True, AniDB_dict, 'Banned')
       title, original_title, language_rank = GetAniDBTitle(AniDBTitlesDB.xpath('/animetitles/anime[@aid="{}"]/title'.format(AniDBid)))
       Log.Info("[ ] 'title': {}, original_title: {}, language_rank: {}".format(title, original_title, language_rank))
       if AniDBid==original or len(full_array)==1:

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -122,7 +122,7 @@ def Update(metadata, media, lang, force, movie):
   dict_OMDb                                                     =        OMDb.GetMetadata(movie, IMDbid) if Prefs['OMDbApiKey'] not in ('None', '', 'N/A') else {}  #TVDBid=='hentai'
   dict_MyAnimeList                                              = MyAnimeList.GetMetadata(movie, MALid ) if MALid                                          else {} #
   dict_Local                                                    =       Local.GetMetadata(media, movie)
-  if common.AdjustMapping(source, mappingList, dict_TheTVDB):
+  if common.AdjustMapping(source, mappingList, dict_AniDB, dict_TheTVDB):
     dict_AniDB, ANNid, MALid                                    =       AniDB.GetMetadata(media, movie, error_log,       source, AniDBid, TVDBid, AniDBMovieSets, mappingList)
   Log.Info("".ljust(157, '-')) 
   Log.Info("Update() - AniDBid: '{}', TVDBid: '{}', TMDbid: '{}', IMDbid: '{}', ANNid:'{}', MALid: '{}'".format(AniDBid, TVDBid, TMDbid, IMDbid, ANNid, MALid))

--- a/Contents/Code/common.py
+++ b/Contents/Code/common.py
@@ -766,7 +766,7 @@ def SortTitle(title, language="en"):
   prefix = title.split  (" ", 1)[0]  #Log.Info("SortTitle - title:{}, language:{}, prefix:{}".format(title, language, prefix))
   return title.replace(prefix+" ", "", 1) if language in dict_sort and prefix in dict_sort[language] else title 
 
-def AdjustMapping(source, mappingList, dict_TheTVDB):
+def AdjustMapping(source, mappingList, dict_AniDB, dict_TheTVDB):
   # EX:
   # season_map: {'max_season': 2, '12560': {'max': 1, 'min': 1}, '13950': {'max': 0, 'min': 0}}
   # relations_map: {'12560': {'Sequel': ['13950']}, '13950': {'Prequel': ['12560']}}
@@ -783,6 +783,7 @@ def AdjustMapping(source, mappingList, dict_TheTVDB):
   Log.Info("common.AdjustMapping() - adjusting mapping for 'anidb3/tvdb' & 'anidb4/tvdb6' usage") 
   is_modified   = False
   tvdb6_seasons = {1: 1}
+  is_banned     = Dict(dict_AniDB,  'Banned',        default=False)
   TVDB          = Dict(mappingList, 'TVDB',          default={})
   season_map    = Dict(mappingList, 'season_map',    default={})
   relations_map = Dict(mappingList, 'relations_map', default={})
@@ -792,63 +793,72 @@ def AdjustMapping(source, mappingList, dict_TheTVDB):
   Log.Info("relations_map: {}".format(relations_map))
   Log.Info("TVDB Before: {}".format(TVDB))
 
-  for id in season_map:
-    new_season, new_episode = '', ''
-    if id == 'max_season':  continue
-    Log.Info("Checking AniDBid: %s" % id)
-    def get_prequel_info(prequel_id):
-      Log.Info("-- get_prequel_info(prequel_id): %s, season min: %s, season max: %s" % (prequel_id, season_map[prequel_id]['min'], season_map[prequel_id]['max']))
+  try:
+    for id in season_map:
+      new_season, new_episode = '', ''
+      if id == 'max_season':  continue
+      Log.Info("Checking AniDBid: %s" % id)
+      def get_prequel_info(prequel_id):
+        Log.Info("-- get_prequel_info(prequel_id): %s, season min: %s, season max: %s" % (prequel_id, season_map[prequel_id]['min'], season_map[prequel_id]['max']))
+        if source=="tvdb":
+          if season_map[prequel_id]['min'] == 0 and 'Prequel' in relations_map[prequel_id] and relations_map[prequel_id]['Prequel'][0] in season_map:
+            a, b = get_prequel_info(relations_map[prequel_id]['Prequel'][0])             # Recurively go down the tree following prequels
+            if not str(a).isdigit():  return ('', '')
+            return (a, b+100) if a < season_map['max_season'] else (a+1, 0)  # If the prequel is < max season, add 100 to the episode number offset: Else, add it into the next new season at episode 0
+          if season_map[prequel_id]['min'] == 0:                          return ('', '')                              # Root prequel is a special so leave mapping alone as special
+          elif season_map[prequel_id]['max'] < season_map['max_season']:  return (season_map[prequel_id]['max'], 100)  # Root prequel season is < max season so add to the end of the Prequel season
+          else:                                                           return (season_map['max_season']+1, 0)       # Root prequel season is >= max season so add to the season after max
+        if source=="tvdb6":
+          if season_map[prequel_id]['min'] != 1 and 'Prequel' in relations_map[prequel_id] and relations_map[prequel_id]['Prequel'][0] in season_map:
+            a, b = get_prequel_info(relations_map[prequel_id]['Prequel'][0])             # Recurively go down the tree following prequels
+            #Log.Info("%s+%s+%s-%s" % (a,1,season_map[prequel_id]['max'],season_map[prequel_id]['min']))
+            return (a+1+season_map[prequel_id]['max']-season_map[prequel_id]['min'], 0) if str(a).isdigit() else ('', '') # Add 1 to the season number and start at episode 0
+          return (2, 0) if season_map[prequel_id]['min'] == 1 else ('', '')              # Root prequel is season 1 so start counting up. Else was a sequel of specials only so leave mapping alone
       if source=="tvdb":
-        if season_map[prequel_id]['min'] == 0 and 'Prequel' in relations_map[prequel_id] and relations_map[prequel_id]['Prequel'][0] in season_map:
-          a, b = get_prequel_info(relations_map[prequel_id]['Prequel'][0])             # Recurively go down the tree following prequels
-          if not str(a).isdigit():  return ('', '')
-          return (a, b+100) if a < season_map['max_season'] else (a+1, 0)  # If the prequel is < max season, add 100 to the episode number offset: Else, add it into the next new season at episode 0
-        if season_map[prequel_id]['min'] == 0:                          return ('', '')                              # Root prequel is a special so leave mapping alone as special
-        elif season_map[prequel_id]['max'] < season_map['max_season']:  return (season_map[prequel_id]['max'], 100)  # Root prequel season is < max season so add to the end of the Prequel season
-        else:                                                           return (season_map['max_season']+1, 0)       # Root prequel season is >= max season so add to the season after max
+        if season_map[id]['min'] == 0 and 'Prequel' in relations_map[id] and relations_map[id]['Prequel'][0] in season_map:
+          new_season, new_episode = get_prequel_info(relations_map[id]['Prequel'][0])    # Recurively go down the tree following prequels to a TVDB season non-0 AniDB prequel 
       if source=="tvdb6":
-        if season_map[prequel_id]['min'] != 1 and 'Prequel' in relations_map[prequel_id] and relations_map[prequel_id]['Prequel'][0] in season_map:
-          a, b = get_prequel_info(relations_map[prequel_id]['Prequel'][0])             # Recurively go down the tree following prequels
-          #Log.Info("%s+%s+%s-%s" % (a,1,season_map[prequel_id]['max'],season_map[prequel_id]['min']))
-          return (a+1+season_map[prequel_id]['max']-season_map[prequel_id]['min'], 0) if str(a).isdigit() else ('', '') # Add 1 to the season number and start at episode 0
-        return (2, 0) if season_map[prequel_id]['min'] == 1 else ('', '')              # Root prequel is season 1 so start counting up. Else was a sequel of specials only so leave mapping alone
-    if source=="tvdb":
-      if season_map[id]['min'] == 0 and 'Prequel' in relations_map[id] and relations_map[id]['Prequel'][0] in season_map:
-        new_season, new_episode = get_prequel_info(relations_map[id]['Prequel'][0])    # Recurively go down the tree following prequels to a TVDB season non-0 AniDB prequel 
+        if 'Prequel' in relations_map[id] and relations_map[id]['Prequel'][0] in season_map:
+          new_season, new_episode = get_prequel_info(relations_map[id]['Prequel'][0])    # Recurively go down the tree following prequels to the TVDB season 1 AniDB prequel 
+
+      if str(new_season).isdigit():  # A new season & eppisode offset has been assigned # As anidb4/tvdb6 does full season adjustments, we need to remove and existing season mapping
+        is_modified = True
+        for key in TVDB.keys():
+          if isinstance(TVDB[key], dict)  and id in TVDB[key]:
+            Log.Info("-- Deleted: %s: {'%s': '%s'}" % (key, id, TVDB[key][id]))
+            del TVDB[key][id]  # Delete season entries for its old anidb non-s0 season entries | 's4': {'11350': '0'}
+          if isinstance(TVDB[key], tuple) and TVDB[key][0] == '1' and TVDB[key][2] == id:
+            Log.Info("-- Deleted: {}: {}".format(key, TVDB[key]))
+            del TVDB[key]      # Delete episode entries for its old anidb s1 entries           | 's0e5': ('1', '4', '9453')
+        SaveDict(str(new_episode), TVDB, 's'+str(new_season), id)
+        Log.Info("-- Added  : {}: {}".format('s'+str(new_season), {id: str(new_episode)}))
+
+      if source=="tvdb6" and str(new_season).isdigit():  tvdb6_seasons[new_season] = season_map[id]['min']  # tvdb6_seasons[New season] = [Old season]
+
+    # Push back the 'dict_TheTVDB' season munbers if tvdb6 for the new inserted season
     if source=="tvdb6":
-      if 'Prequel' in relations_map[id] and relations_map[id]['Prequel'][0] in season_map:
-        new_season, new_episode = get_prequel_info(relations_map[id]['Prequel'][0])    # Recurively go down the tree following prequels to the TVDB season 1 AniDB prequel 
+      top_season, season, adjustment, new_seasons = max(map(int, dict_TheTVDB['seasons'].keys())), 1, 0, {}
+      Log.Info("dict_TheTVDB Seasons Before : {}".format(sorted(dict_TheTVDB['seasons'].keys(), key=int)))
+      Log.Info("tvdb6_seasons : {}".format(tvdb6_seasons))
+      if "0" in dict_TheTVDB['seasons']:  new_seasons["0"] = dict_TheTVDB['seasons'].pop("0")
+      while season <= top_season:
+        if Dict(tvdb6_seasons, season + adjustment) == 0:
+          Log.Info("-- New TVDB season  '{}'".format(season + adjustment))
+          adjustment += 1
+        else:
+          Log.Info("-- Adjusting season '{}' -> '{}'".format(season, season + adjustment))
+          if str(season) in dict_TheTVDB['seasons']:  new_seasons[str(season + adjustment)] = dict_TheTVDB['seasons'].pop(str(season))
+          season += 1
+      SaveDict(new_seasons, dict_TheTVDB, 'seasons')
+      Log.Info("dict_TheTVDB Seasons After  : {}".format(sorted(dict_TheTVDB['seasons'].keys(), key=int)))
 
-    if str(new_season).isdigit():  # A new season & eppisode offset has been assigned # As anidb4/tvdb6 does full season adjustments, we need to remove and existing season mapping
-      is_modified = True
-      for key in TVDB.keys():
-        if isinstance(TVDB[key], dict)  and id in TVDB[key]:
-          Log.Info("-- Deleted: %s: {'%s': '%s'}" % (key, id, TVDB[key][id]))
-          del TVDB[key][id]  # Delete season entries for its old anidb non-s0 season entries | 's4': {'11350': '0'}
-        if isinstance(TVDB[key], tuple) and TVDB[key][0] == '1' and TVDB[key][2] == id:
-          Log.Info("-- Deleted: {}: {}".format(key, TVDB[key]))
-          del TVDB[key]      # Delete episode entries for its old anidb s1 entries           | 's0e5': ('1', '4', '9453')
-      SaveDict(str(new_episode), TVDB, 's'+str(new_season), id)
-      Log.Info("-- Added  : {}: {}".format('s'+str(new_season), {id: str(new_episode)}))
-
-    if source=="tvdb6" and str(new_season).isdigit():  tvdb6_seasons[new_season] = season_map[id]['min']  # tvdb6_seasons[New season] = [Old season]
-
-  # Push back the 'dict_TheTVDB' season munbers if tvdb6 for the new inserted season
-  if source=="tvdb6":
-    top_season, season, adjustment, new_seasons = max(map(int, dict_TheTVDB['seasons'].keys())), 1, 0, {}
-    Log.Info("dict_TheTVDB Seasons Before : {}".format(sorted(dict_TheTVDB['seasons'].keys(), key=int)))
-    Log.Info("tvdb6_seasons : {}".format(tvdb6_seasons))
-    if "0" in dict_TheTVDB['seasons']:  new_seasons["0"] = dict_TheTVDB['seasons'].pop("0")
-    while season <= top_season:
-      if Dict(tvdb6_seasons, season + adjustment) == 0:
-        Log.Info("-- New TVDB season  '{}'".format(season + adjustment))
-        adjustment += 1
-      else:
-        Log.Info("-- Adjusting season '{}' -> '{}'".format(season, season + adjustment))
-        if str(season) in dict_TheTVDB['seasons']:  new_seasons[str(season + adjustment)] = dict_TheTVDB['seasons'].pop(str(season))
-        season += 1
-    SaveDict(new_seasons, dict_TheTVDB, 'seasons')
-    Log.Info("dict_TheTVDB Seasons After  : {}".format(sorted(dict_TheTVDB['seasons'].keys(), key=int)))
+  except Exception as e:
+    if is_banned:  Log.Info("Expected exception hit, as you were banned from AniDB so you have incomplete data to proceed")
+    else:          Log.Error("Unexpected exception hit")
+    Log.Info('Exception: "{}"'.format(e))
+    Log.Info("Removing AniDB & TVDB data from memory to prevent incorrect data from being loaded")
+    dict_AniDB, dict_TheTVDB = {}, {}
+    return False
 
   Log.Info("TVDB After : {}".format(Dict(mappingList, 'TVDB')))
   return is_modified


### PR DESCRIPTION
Hey @ZeroQI,

Take a look. This will handle data issues from a ban better and just clear out info instead of it just crashing to handle that.

If exception is hit in `common.AdjustMapping`, it will clear out dict_AniDB & dict_TheTVDB to an empty dict.
Also notes if an AniDB ban was hit so it knows how to log the exception

```python
  except Exception as e:
    if is_banned:  Log.Info("Expected exception hit, as you were banned from AniDB so you have incomplete data to proceed")
    else:          Log.Error("Unexpected exception hit")
    Log.Info('Exception: "{}"'.format(e))
    Log.Info("Removing AniDB & TVDB data from memory to prevent incorrect data from being loaded")
    dict_AniDB, dict_TheTVDB = {}, {}
    return False
```

Diff output is not really much change on last [commit](https://github.com/ZeroQI/Hama.bundle/commit/f3a11a5220e23934aa672efbd7b2ab5b5b56a2d0). Its just a bad interpretation of most just getting indented to be put under a try/except.

Apply 'Hide whitespace changes' and it looks a lot better.
![image](https://user-images.githubusercontent.com/16750699/53387083-d119c180-394a-11e9-8874-2bc4eaa9799f.png)
