### PR TITLE
EOL: Multiple Enhancements/Fixes

### DIFF
--- a/Contents/Code/AniDB.py
+++ b/Contents/Code/AniDB.py
@@ -132,7 +132,7 @@ def GetMetadata(media, movie, error_log, source, AniDBid, TVDBid, AniDBMovieSets
   Log.Info('language_posters: {}'.format(language_posters))
   
   ### Load anidb xmls in tvdb numbering format if needed ###
-  for AniDBid in (full_array if source in ["tvdb", "tvdb6"] else AniDB_array):  # Only pull all if anidb3(tvdb)/anidb4(tvdb6) usage
+  for AniDBid in full_array if source in ["tvdb", "tvdb6"] else AniDB_array:  # Only pull all if anidb3(tvdb)/anidb4(tvdb6) usage
     is_primary_entry = AniDBid==original or len(full_array if source in ["tvdb", "tvdb6"] else AniDB_array)==1
 
     Log.Info(("--- %s ---" % AniDBid).ljust(157, '-'))

--- a/Contents/Code/AniDB.py
+++ b/Contents/Code/AniDB.py
@@ -132,8 +132,8 @@ def GetMetadata(media, movie, error_log, source, AniDBid, TVDBid, AniDBMovieSets
   Log.Info('language_posters: {}'.format(language_posters))
   
   ### Load anidb xmls in tvdb numbering format if needed ###
-  for AniDBid in full_array:
-    is_primary_entry = AniDBid==original or len(full_array)==1
+  for AniDBid in (full_array if source in ["tvdb", "tvdb6"] else AniDB_array):  # Only pull all if anidb3(tvdb)/anidb4(tvdb6) usage
+    is_primary_entry = AniDBid==original or len(full_array if source in ["tvdb", "tvdb6"] else AniDB_array)==1
 
     Log.Info(("--- %s ---" % AniDBid).ljust(157, '-'))
     Log.Info('AniDBid: {}, IsPrimary: {}, url: {}'.format(AniDBid, is_primary_entry, ANIDB_HTTP_API_URL+AniDBid))

--- a/Contents/Code/AniDB.py
+++ b/Contents/Code/AniDB.py
@@ -251,8 +251,8 @@ def GetMetadata(media, movie, error_log, source, AniDBid, TVDBid, AniDBMovieSets
 
             # Get season from absolute number OR convert episode number to absolute number
             if source in ('tvdb3', 'tvdb4') and season not in ('-1', '0'):
-              season = Dict(mappingList, 'absolute_map', episode, default=(season, episode))[0]
-              if episode!='0':
+              if season=='1' or source=='tvdb4':  season = Dict(mappingList, 'absolute_map', episode, default=(season, episode))[0]
+              elif episode!='0':
                 try:  episode = list(Dict(mappingList, 'absolute_map', default={}).keys())[list(Dict(mappingList, 'absolute_map', default={}).values()).index((season, episode))]
                 except Exception as e:  Log.Error("Exception: {}".format(e))
 

--- a/Contents/Code/AniDB.py
+++ b/Contents/Code/AniDB.py
@@ -295,7 +295,8 @@ def GetMetadata(media, movie, error_log, source, AniDBid, TVDBid, AniDBMovieSets
           
           SaveDict(GetXml(ep_obj, 'rating' ), AniDB_dict, 'seasons', season, 'episodes', episode, 'rating'                 )
           SaveDict(GetXml(ep_obj, 'airdate'), AniDB_dict, 'seasons', season, 'episodes', episode, 'originally_available_at')
-          if SaveDict(summary_sanitizer(GetXml(ep_obj, 'summary')), AniDB_dict, 'seasons', season, 'episodes', episode, 'summary'):  Log.Info(" - [ ] summary: {}".format(Dict(AniDB_dict, 'seasons', season, 'episodes', episode, 'summary')))
+          ep_summary = SaveDict(summary_sanitizer(GetXml(ep_obj, 'summary')), AniDB_dict, 'seasons', season, 'episodes', episode, 'summary')
+          Log.Info(' - [ ] summary: {}'.format((ep_summary[:200]).replace("\n", " ")+'..' if len(ep_summary)> 200 else ep_summary))
           for creator in creators:  SaveDict(",".join(creators[creator]), AniDB_dict, 'seasons', season, 'episodes', episode, creator)
                   
         ### End of for ep_obj...

--- a/Contents/Code/AniDB.py
+++ b/Contents/Code/AniDB.py
@@ -117,7 +117,7 @@ def GetMetadata(media, movie, error_log, source, AniDBid, TVDBid, AniDBMovieSets
   ### Build the list of anidbids for files present ####
   if source.startswith("tvdb") or source.startswith("anidb") and not movie and max(map(int, media.seasons.keys()))>1:  #multi anidbid required only for tvdb numbering
     full_array  = [ anidbid for season in Dict(mappingList, 'TVDB') or [] for anidbid in Dict(mappingList, 'TVDB', season) if season and 'e' not in season and anidbid.isdigit() ]
-    AniDB_array = { AniDBid: [] } if Dict(mappingList, 'defaulttvdbseason')=='1' or Dict(mappingList, 'TVDB', 'sa') else {}
+    AniDB_array = { AniDBid: [] } if Dict(mappingList, 'defaulttvdbseason')=='1' else {}
     for season in sorted(media.seasons, key=common.natural_sort_key) if not movie else []:  # For each season, media, then use metadata['season'][season]...
       for episode in sorted(media.seasons[season].episodes, key=common.natural_sort_key):
         new_season, new_episode, anidbid = AnimeLists.anidb_ep(mappingList, season, episode)
@@ -247,12 +247,12 @@ def GetMetadata(media, movie, error_log, source, AniDBid, TVDBid, AniDBMovieSets
           
           #If tvdb numbering used, save anidb episode meta using tvdb numbering
           if source.startswith("tvdb") or source.startswith("anidb") and not movie and max(map(int, media.seasons.keys()))>1:
-            season, episode = AnimeLists.tvdb_ep(mappingList, season, episode, AniDBid) ###Broken for tvdbseason='a'
+            season, episode = AnimeLists.tvdb_ep(mappingList, season, episode, AniDBid)
 
             # Get season from absolute number OR convert episode number to absolute number
             if source in ('tvdb3', 'tvdb4') and season not in ('-1', '0'):
-              if season=='a' or source=='tvdb4':  season = Dict(mappingList, 'absolute_map', episode, default=(season, episode))[0]
-              elif episode!='0':
+              season = Dict(mappingList, 'absolute_map', episode, default=(season, episode))[0]
+              if episode!='0':
                 try:  episode = list(Dict(mappingList, 'absolute_map', default={}).keys())[list(Dict(mappingList, 'absolute_map', default={}).values()).index((season, episode))]
                 except Exception as e:  Log.Error("Exception: {}".format(e))
 

--- a/Contents/Code/AniDB.py
+++ b/Contents/Code/AniDB.py
@@ -300,7 +300,7 @@ def GetMetadata(media, movie, error_log, source, AniDBid, TVDBid, AniDBMovieSets
                   
         ### End of for ep_obj...
         Log.Info(("--- %s.summary info ---" % AniDBid).ljust(157, '-'))
-        if SaveDict(int(totalDuration)/int(numEpisodes) if int(numEpisodes) else 0, AniDB_dict, 'duration'):
+        if SaveDict((int(totalDuration)/int(numEpisodes))*60*1000 if int(numEpisodes) else 0, AniDB_dict, 'duration'):
           Log.Info("Duration: {}, numEpisodes: {}, average duration: {}".format(str(totalDuration), str(numEpisodes), AniDB_dict['duration']))
 
         ### AniDB numbering Missing Episodes ###

--- a/Contents/Code/AniDB.py
+++ b/Contents/Code/AniDB.py
@@ -132,7 +132,7 @@ def GetMetadata(media, movie, error_log, source, AniDBid, TVDBid, AniDBMovieSets
   Log.Info('language_posters: {}'.format(language_posters))
   
   ### Load anidb xmls in tvdb numbering format if needed ###
-  for AniDBid in full_array if source in ["tvdb", "tvdb6"] else AniDB_array:  # Only pull all if anidb3(tvdb)/anidb4(tvdb6) usage
+  for AniDBid in full_array if source in ["tvdb", "tvdb6"] else AniDB_array:  # Only pull all if anidb3(tvdb)/anidb4(tvdb6) usage for full relation_map data
     is_primary_entry = AniDBid==original or len(full_array if source in ["tvdb", "tvdb6"] else AniDB_array)==1
 
     Log.Info(("--- %s ---" % AniDBid).ljust(157, '-'))

--- a/Contents/Code/AniDB.py
+++ b/Contents/Code/AniDB.py
@@ -132,7 +132,7 @@ def GetMetadata(media, movie, error_log, source, AniDBid, TVDBid, AniDBMovieSets
   
   active_array = full_array if source in ("tvdb", "tvdb4", "tvdb6") else AniDB_array.keys()  # anidb3(tvdb)/anidb4(tvdb6) for full relation_map data | tvdb4 bc the above will not be able to know the AniDBid
   Log.Info("Source: {}, AniDBid: {}, Full AniDBids list: {}, Active AniDBids list: {}".format(source, AniDBid, full_array, active_array))
-  for anidbid in AniDB_array:
+  for anidbid in sorted(AniDB_array, key=common.natural_sort_key):
     Log.Info('[+] {:>5}: {}'.format(anidbid, AniDB_array[anidbid]))
   Log.Info('language_posters: {}'.format(language_posters))
   
@@ -146,7 +146,7 @@ def GetMetadata(media, movie, error_log, source, AniDBid, TVDBid, AniDBMovieSets
     Log.Info('Present abs eps: {}'.format(list_abs_eps))
 
   ### Load anidb xmls in tvdb numbering format if needed ###
-  for AniDBid in active_array:
+  for AniDBid in sorted(active_array, key=common.natural_sort_key):
     is_primary_entry = AniDBid==original or len(active_array)==1
 
     Log.Info(("--- %s ---" % AniDBid).ljust(157, '-'))

--- a/Contents/Code/AniDB.py
+++ b/Contents/Code/AniDB.py
@@ -126,14 +126,16 @@ def GetMetadata(media, movie, error_log, source, AniDBid, TVDBid, AniDBMovieSets
       else:  continue
   elif source.startswith('anidb') and AniDBid != "":  full_array, AniDB_array = [AniDBid], {AniDBid:[]}
   else:                                               full_array, AniDB_array = [], {}
-  Log.Info("AniDBid: {}, AniDBids list: {}, source: {}".format(AniDBid, full_array, source))
+  
+  active_array = full_array if source in ["tvdb", "tvdb6"] else AniDB_array.keys()
+  Log.Info("Source: {}, AniDBid: {}, Full AniDBids list: {}, Active AniDBids list: {}".format(source, AniDBid, full_array, active_array))
   for anidbid in AniDB_array:
     Log.Info('[+] {:>5}: {}'.format(anidbid, AniDB_array[anidbid]))
   Log.Info('language_posters: {}'.format(language_posters))
   
   ### Load anidb xmls in tvdb numbering format if needed ###
-  for AniDBid in full_array if source in ["tvdb", "tvdb6"] else AniDB_array:  # Only pull all if anidb3(tvdb)/anidb4(tvdb6) usage for full relation_map data
-    is_primary_entry = AniDBid==original or len(full_array if source in ["tvdb", "tvdb6"] else AniDB_array)==1
+  for AniDBid in active_array:  # Only pull all if anidb3(tvdb)/anidb4(tvdb6) usage for full relation_map data
+    is_primary_entry = AniDBid==original or len(active_array)==1
 
     Log.Info(("--- %s ---" % AniDBid).ljust(157, '-'))
     Log.Info('AniDBid: {}, IsPrimary: {}, url: {}'.format(AniDBid, is_primary_entry, ANIDB_HTTP_API_URL+AniDBid))

--- a/Contents/Code/AnimeLists.py
+++ b/Contents/Code/AnimeLists.py
@@ -264,15 +264,10 @@ def tvdb_ep(mappingList, season, episode, anidbid=''):
 
 ### Translate TVDB numbering into AniDB numbering ###
 def anidb_ep(mappingList, season, episode):
-  
-  # <mapping-list> <mapping anidbseason="0" tvdbseason="0">;1-5;2-6;</mapping> + <mapping-list> <mapping anidbseason="1" tvdbseason="5" start="13" end="24" offset="-12"/>
+  # <mapping-list> <mapping anidbseason="0" tvdbseason="0">;1-5;2-6;</mapping>
+  # <mapping-list> <mapping anidbseason="1" tvdbseason="5" start="13" end="24" offset="-12"/>
   ep_mapping = Dict(mappingList, 'TVDB', 's'+season+'e'+episode.split('-')[0])
   if ep_mapping:  return ep_mapping[0], ep_mapping[1], ep_mapping[2]            #Lvl 3 & 2 direct ep mapping (ep or season with start-end range)
-  
-  ### bug here
-  #ep_mappings   = [key for key in Dict(mappingList, 'TVDB') if 'e' in key and anidbid == Dict(mappingList, 'TVDB', key)[2]]  
-  #Log.Info('ep_mappings: "{}" so dropping non listed ep mappings'.format(ep_mappings));
-  #if ep_mappings:  return '0', '0', anidbid 
   
   # <mapping-list> <mapping anidbseason="1" tvdbseason="5" offset="-12"/>
   anidbid_list = Dict(mappingList, 'TVDB', 's'+season)

--- a/Contents/Code/AnimeLists.py
+++ b/Contents/Code/AnimeLists.py
@@ -169,14 +169,18 @@ def GetMetadata(media, movie, error_log, id):
       # keeping this reset since im not clear on it's purpose.
       AniDBid,TVDBid = '',''
   
+  AniDB_winner = AniDB_id or AniDB_id2 or AniDBid
+  TVDB_winner  = TVDB_id or TVDBid
+  
   Log.Info('             -----          ------')
-  Log.Info('             {:>5}          {:>6}'.format(AniDB_id or AniDB_id2 or AniDBid, TVDB_id or TVDBid))
-  SaveDict(Dict(tvdbcounts, TVDB_id or TVDBid), mappingList, 'tvdbcount')
+  Log.Info('             {:>5}          {:>6}'.format(AniDB_winner, TVDB_winner))
+  
+  SaveDict(Dict(tvdbcounts, TVDB_winner), mappingList, 'tvdbcount')
   
   ### Update collection 
   TVDB_collection, title = [], ''
-  for anime in AniDBTVDBMap.iter('anime') if AniDBTVDBMap and TVDB_id.isdigit() else []:
-    if anime.get('tvdbid',  "") == TVDB_id:
+  for anime in AniDBTVDBMap.iter('anime') if AniDBTVDBMap and TVDB_winner.isdigit() else []:
+    if anime.get('tvdbid',  "") == TVDB_winner:
       TVDB_collection.append(anime.get("anidbid", ""))
       if defaulttvdbseason == '1' and episodeoffset == '0' and len(anime.xpath("mapping-list/mapping[@anidbseason='1'][@tvdbseason='0']")) == 0:
         title = AniDB.GetAniDBTitle(AniDB.AniDBTitlesDB.xpath('/animetitles/anime[@aid="{}"]/title'.format(anime.get("anidbid", ""))))[0]  #returns [title, main, language_rank]
@@ -189,7 +193,7 @@ def GetMetadata(media, movie, error_log, id):
   Log.Info("AniDB_id: '{}', AniDB_id2: '{}', AniDBid: '{}', TVDB_id: '{}', TVDBid: '{}'".format(AniDB_id, AniDB_id2, AniDBid, TVDB_id, TVDBid))
   Log.Info("mappingList: {}".format(DictString(mappingList, 1)))
   Log.Info("AnimeLists_dict: {}".format(DictString(AnimeLists_dict, 1)))
-  return AnimeLists_dict, AniDB_id or AniDB_id2 or AniDBid, (TVDB_id or TVDBid) if (TVDB_id or TVDBid).isdigit() else "", Dict(mappingList, 'tmdbid'), Dict(mappingList, 'imdbid'), mappingList
+  return AnimeLists_dict, AniDB_winner, TVDB_winner if TVDB_winner.isdigit() else "", Dict(mappingList, 'tmdbid'), Dict(mappingList, 'imdbid'), mappingList
 
 ### Translate AniDB numbering into TVDB numbering ###
 def tvdb_ep(mappingList, season, episode, anidbid=''):

--- a/Contents/Code/AnimeLists.py
+++ b/Contents/Code/AnimeLists.py
@@ -105,14 +105,15 @@ def GetMetadata(media, movie, error_log, id):
     
     ### Anidb numbered serie ###
     if AniDB_id: # or defaulttvdbseason=='1':
-      SaveDict(anime.get('tmdbid',        ""),              mappingList, 'tmdbid'           )
-      SaveDict(anime.get('imdbid',        ""),              mappingList, 'imdbid'           )
-      SaveDict(defaulttvdbseason,                           mappingList, 'defaulttvdbseason')
-      SaveDict(episodeoffset,                               mappingList, 'episodeoffset'    )
-      SaveDict(GetXml(anime, 'name'         ),              mappingList, 'name'             )
-      SaveDict(GetXml(anime, "supplemental-info/studio"  ), AnimeLists_dict, 'studio'        )
-      SaveDict(GetXml(anime, "supplemental-info/director"), AnimeLists_dict, 'director'      )
-      SaveDict(GetXml(anime, "supplemental-info/credits" ), AnimeLists_dict, 'writer'        )
+      SaveDict(anime.get('tmdbid', ""),                                mappingList, 'tmdbid'             )
+      SaveDict(anime.get('imdbid', ""),                                mappingList, 'imdbid'             )
+      SaveDict(defaulttvdbseason,                                      mappingList, 'defaulttvdbseason'  )
+      SaveDict(True if anime.get('defaulttvdbseason')=='a' else False, mappingList, 'defaulttvdbseason_a')
+      SaveDict(episodeoffset,                                          mappingList, 'episodeoffset'      )
+      SaveDict(GetXml(anime, 'name'         ),                         mappingList, 'name'               )
+      SaveDict(GetXml(anime, "supplemental-info/studio"  ),            AnimeLists_dict, 'studio'         )
+      SaveDict(GetXml(anime, "supplemental-info/director"),            AnimeLists_dict, 'director'       )
+      SaveDict(GetXml(anime, "supplemental-info/credits" ),            AnimeLists_dict, 'writer'         )
       for genre in anime.xpath('supplemental-info/genre'):         SaveDict([genre.text],                                                          AnimeLists_dict, 'genres')
       for art   in anime.xpath('supplemental-info/fanart/thumb'):  SaveDict({art.text:('/'.join(art.text.split('/')[3:]), 1, art.get('preview'))}, AnimeLists_dict, 'art'   )
       
@@ -121,7 +122,8 @@ def GetMetadata(media, movie, error_log, id):
       if TVDBid.isdigit():
         if defaulttvdbseason:
           if defaulttvdbseason == '1' and episodeoffset == '0' and len(s1_mapping) == 0:
-            SaveDict(defaulttvdbseason, mappingList, 'defaulttvdbseason')
+            SaveDict(defaulttvdbseason,                                      mappingList, 'defaulttvdbseason'  )
+            SaveDict(True if anime.get('defaulttvdbseason')=='a' else False, mappingList, 'defaulttvdbseason_a')
             AniDB_id2 = AniDBid
           SaveDict(episodeoffset, mappingList, 'TVDB', 's-1' if defaulttvdbseason == '0' and len(s1_mapping) >= 1 else 's'+defaulttvdbseason, AniDBid)  #mappingList['TVDB'][s1][anidbid]=episodeoffset
           SaveDict({'min': defaulttvdbseason, 'max': defaulttvdbseason}, mappingList, 'season_map', AniDBid)  # Set the min/max season to the 'defaulttvdbseason'

--- a/Contents/Code/AnimeLists.py
+++ b/Contents/Code/AnimeLists.py
@@ -182,11 +182,13 @@ def GetMetadata(media, movie, error_log, id):
   for anime in AniDBTVDBMap.iter('anime') if AniDBTVDBMap and TVDB_winner.isdigit() else []:
     if anime.get('tvdbid',  "") == TVDB_winner:
       TVDB_collection.append(anime.get("anidbid", ""))
+      defaulttvdbseason = anime.get('defaulttvdbseason') if anime.get('defaulttvdbseason') and anime.get('defaulttvdbseason') != 'a' else '1'
+      episodeoffset     = anime.get('episodeoffset')     if anime.get('episodeoffset')                                               else '0'
       if defaulttvdbseason == '1' and episodeoffset == '0' and len(anime.xpath("mapping-list/mapping[@anidbseason='1'][@tvdbseason='0']")) == 0:
         title = AniDB.GetAniDBTitle(AniDB.AniDBTitlesDB.xpath('/animetitles/anime[@aid="{}"]/title'.format(anime.get("anidbid", ""))))[0]  #returns [title, main, language_rank]
-        studio = GetXml(anime, "supplemental-info/studio")  #anime.xpath("supplemental-info/studio")
+        studio = GetXml(anime, "supplemental-info/studio")
   if len(TVDB_collection)>1 and title:  # Require that there be at least 2 anidb mappings for a collection
-    Log.Info("[ ] collection: TVDBid '%s' is part of collection: '%s'" % (TVDB_winner, SaveDict([title + ' Collection'], AnimeLists_dict, 'collections')))
+    Log.Info("[ ] collection: TVDBid '%s' is part of collection: '%s', related_anime_list: %s" % (TVDB_winner, SaveDict([title + ' Collection'], AnimeLists_dict, 'collections'), TVDB_collection))
   else:  Log.Info("[ ] collection: TVDBid '%s' is not part of any collection" % TVDB_winner)
   Log.Info("[ ] studio: {}".format(SaveDict(studio, AnimeLists_dict, 'studio')))
   

--- a/Contents/Code/AnimeLists.py
+++ b/Contents/Code/AnimeLists.py
@@ -177,17 +177,18 @@ def GetMetadata(media, movie, error_log, id):
   
   SaveDict(Dict(tvdbcounts, TVDB_winner), mappingList, 'tvdbcount')
   
-  ### Update collection 
-  TVDB_collection, title = [], ''
+  ### Update collection/studio
+  TVDB_collection, title, studio = [], '', ''
   for anime in AniDBTVDBMap.iter('anime') if AniDBTVDBMap and TVDB_winner.isdigit() else []:
     if anime.get('tvdbid',  "") == TVDB_winner:
       TVDB_collection.append(anime.get("anidbid", ""))
       if defaulttvdbseason == '1' and episodeoffset == '0' and len(anime.xpath("mapping-list/mapping[@anidbseason='1'][@tvdbseason='0']")) == 0:
         title = AniDB.GetAniDBTitle(AniDB.AniDBTitlesDB.xpath('/animetitles/anime[@aid="{}"]/title'.format(anime.get("anidbid", ""))))[0]  #returns [title, main, language_rank]
-  if len(TVDB_collection)>1 and title:
-    SaveDict([title + ' Collection'], AnimeLists_dict, 'collections')
-    Log.Info("[ ] collection: TVDBid '%s' is part of collection: '%s'" % (TVDB_id, title))
-  else:  Log.Info("[ ] collection: TVDBid '%s' is not part of any collection" % (TVDB_id))
+        studio = GetXml(anime, 'studio')  #anime.xpath("supplemental-info/studio")
+  if len(TVDB_collection)>1 and title:  # Require that there be at least 2 anidb mappings for a collection
+    Log.Info("[ ] collection: TVDBid '%s' is part of collection: '%s'" % (TVDB_winner, SaveDict([title + ' Collection'], AnimeLists_dict, 'collections')))
+  else:  Log.Info("[ ] collection: TVDBid '%s' is not part of any collection" % TVDB_winner)
+  Log.Info("[ ] studio: {}".format(SaveDict(studio, AnimeLists_dict, 'studio')))
   
   Log.Info("--- return ---".ljust(157, '-'))
   Log.Info("AniDB_id: '{}', AniDB_id2: '{}', AniDBid: '{}', TVDB_id: '{}', TVDBid: '{}'".format(AniDB_id, AniDB_id2, AniDBid, TVDB_id, TVDBid))

--- a/Contents/Code/AnimeLists.py
+++ b/Contents/Code/AnimeLists.py
@@ -92,11 +92,11 @@ def GetMetadata(media, movie, error_log, id):
 
     defaulttvdbseason = anime.get('defaulttvdbseason') if anime.get('defaulttvdbseason') and anime.get('defaulttvdbseason') != 'a' else '1'
     episodeoffset     = anime.get('episodeoffset')     if anime.get('episodeoffset')                                               else '0'
-    if anime.get('defaulttvdbseason') != defaulttvdbseason:  Log.Info("Overriding 'defaulttvdbseason': '{}'->'{}'".format(anime.get('defaulttvdbseason'), defaulttvdbseason))
 
     if not tvdb_numbering and not TVDB_id:                                                                                                                                                                           TVDB_id   = TVDBid
     if tvdb_numbering and AniDBid and TVDBid.isdigit() and defaulttvdbseason == '1' and episodeoffset == '0' and len(anime.xpath("mapping-list/mapping[@anidbseason='1'][@tvdbseason='0']")) == 0 and not AniDB_id:  AniDB_id2 = AniDBid
-    Log.Info("[+] AniDBid: {:>5}, TVDBid: {:>6}, defaulttvdbseason: {:>2}, offset: {:>3}, name: {}".format(AniDBid, TVDBid, defaulttvdbseason, episodeoffset, GetXml(anime, 'name')))
+    Log.Info("[+] AniDBid: {:>5}, TVDBid: {:>6}, defaulttvdbseason: {:>3}, offset: {:>3}, name: {}".format(AniDBid, TVDBid, 
+      ("({})".format(anime.get('defaulttvdbseason')) if anime.get('defaulttvdbseason')!=defaulttvdbseason else '')+defaulttvdbseason, episodeoffset, GetXml(anime, 'name')))
     
     ### Anidb numbered serie ###
     if AniDB_id: # or defaulttvdbseason=='1':
@@ -123,7 +123,7 @@ def GetMetadata(media, movie, error_log, id):
           if source=="tvdb6" and int(episodeoffset)>0:  SaveDict({'min': '0', 'max': '0'}, mappingList, 'season_map', AniDBid)  # Force series as special if not starting the TVDB season
         for season in anime.iter('mapping'):  ### mapping list: <mapping-list> <mapping anidbseason="0" tvdbseason="0">;1-12;2-14;3-16;4-18;</mapping> </mapping-list> 
           anidbseason, tvdbseason, offset, start, end = season.get('anidbseason'), season.get('tvdbseason'), season.get('offset') or '0', season.get('start'), season.get('end')
-          Log.Info("    - season: [{:>2}],           [{:>2}], range:      [{:>3}-{:>3}], offset: {:>3}, text: {}".format(anidbseason, tvdbseason, start or '000', end or '000', offset, (season.text or '').strip(';')))
+          Log.Info("    - season: [{:>2}],           [{:>2}], range:       [{:>3}-{:>3}], offset: {:>3}, text: {}".format(anidbseason, tvdbseason, start or '000', end or '000', offset, (season.text or '').strip(';')))
           for ep in range(int(start), int(end)+1)        if start       else []:
             #Log.Info("[?] start: {}, end: {}, ep: {}".format(start, end, ep))
             if not Dict(mappingList, 'TVDB', 's'+tvdbseason+'e'+str(ep+int(offset))):

--- a/Contents/Code/AnimeLists.py
+++ b/Contents/Code/AnimeLists.py
@@ -92,6 +92,7 @@ def GetMetadata(media, movie, error_log, id):
 
     defaulttvdbseason = anime.get('defaulttvdbseason') if anime.get('defaulttvdbseason') and anime.get('defaulttvdbseason') != 'a' else '1'
     episodeoffset     = anime.get('episodeoffset')     if anime.get('episodeoffset')                                               else '0'
+    if anime.get('defaulttvdbseason') != defaulttvdbseason:  Log.Info("Overriding 'defaulttvdbseason': '{}'->'{}'".format(anime.get('defaulttvdbseason'), defaulttvdbseason))
 
     if not tvdb_numbering and not TVDB_id:                                                                                                                                                                           TVDB_id   = TVDBid
     if tvdb_numbering and AniDBid and TVDBid.isdigit() and defaulttvdbseason == '1' and episodeoffset == '0' and len(anime.xpath("mapping-list/mapping[@anidbseason='1'][@tvdbseason='0']")) == 0 and not AniDB_id:  AniDB_id2 = AniDBid
@@ -160,7 +161,7 @@ def GetMetadata(media, movie, error_log, id):
     if ( (TMDB_id or TMDBid) or IMDBid ):
       SaveDict(TMDB_id or TMDBid or '', mappingList, 'tmdbid')
       SaveDict(IMDBid or '', mappingList, 'imdbid')
-      Log.Info("Saved possible tmdb/imdb values for later '%s'/'%s' for later, since not in AnimeList." % (Dict(mappingList,'tmdbid'), Dict(mappingList,'imdbid')))
+      Log.Info("Saved possible tmdb/imdb values for later ('%s'/'%s'), since not in AnimeList." % (Dict(mappingList,'tmdbid'), Dict(mappingList,'imdbid')))
     elif not found:
       Log.Info("ERROR: Could not find %s: %s" % (source, id) )
       # this error only makes sense if it's AniDB_id, right? otherwise AniDB_id is always == ""

--- a/Contents/Code/AnimeLists.py
+++ b/Contents/Code/AnimeLists.py
@@ -104,7 +104,7 @@ def GetMetadata(media, movie, error_log, id):
       SaveDict(defaulttvdbseason,                           mappingList, 'defaulttvdbseason')
       SaveDict(episodeoffset,                               mappingList, 'episodeoffset'    )
       SaveDict(GetXml(anime, 'name'         ),              mappingList, 'name'             )
-      SaveDict(GetXml(anime, 'studio'                    ), AnimeLists_dict, 'studio'        )
+      SaveDict(GetXml(anime, "supplemental-info/studio"  ), AnimeLists_dict, 'studio'        )
       SaveDict(GetXml(anime, "supplemental-info/director"), AnimeLists_dict, 'director'      )
       SaveDict(GetXml(anime, "supplemental-info/credits" ), AnimeLists_dict, 'writer'        )
       for genre in anime.xpath('supplemental-info/genre'):         SaveDict([genre.text],                                                          AnimeLists_dict, 'genres')
@@ -184,7 +184,7 @@ def GetMetadata(media, movie, error_log, id):
       TVDB_collection.append(anime.get("anidbid", ""))
       if defaulttvdbseason == '1' and episodeoffset == '0' and len(anime.xpath("mapping-list/mapping[@anidbseason='1'][@tvdbseason='0']")) == 0:
         title = AniDB.GetAniDBTitle(AniDB.AniDBTitlesDB.xpath('/animetitles/anime[@aid="{}"]/title'.format(anime.get("anidbid", ""))))[0]  #returns [title, main, language_rank]
-        studio = GetXml(anime, 'studio')  #anime.xpath("supplemental-info/studio")
+        studio = GetXml(anime, "supplemental-info/studio")  #anime.xpath("supplemental-info/studio")
   if len(TVDB_collection)>1 and title:  # Require that there be at least 2 anidb mappings for a collection
     Log.Info("[ ] collection: TVDBid '%s' is part of collection: '%s'" % (TVDB_winner, SaveDict([title + ' Collection'], AnimeLists_dict, 'collections')))
   else:  Log.Info("[ ] collection: TVDBid '%s' is not part of any collection" % TVDB_winner)

--- a/Contents/Code/TheTVDBv2.py
+++ b/Contents/Code/TheTVDBv2.py
@@ -134,7 +134,7 @@ def GetMetadata(media, movie, error_log, lang, metadata_source, AniDBid, TVDBid,
         if season!='0' and Dict(mappingList, 'defaulttvdbseason_a'):  season, episode          = '1', str(abs_number)
         else:                                                         season, episode, anidbid = anidb_ep(mappingList, season, episode)
       elif season!='0' and metadata_source=='tvdb3':  episode             = str(abs_number)
-      elif season!='0' and metadata_source=='tvdb4':  season, episode     = Dict(mappingList, 'absolute_map', episode, default=(season, episode))[0], str(abs_number)
+      elif season!='0' and metadata_source=='tvdb4':  season, episode     = Dict(mappingList, 'absolute_map', str(abs_number), default=(season, str(abs_number)))[0], str(abs_number)
       elif season!='0' and metadata_source=='tvdb5':  episode, abs_number = str(Dict(episode_json, 'absoluteNumber') or abs_number), int(Dict(episode_json, 'absoluteNumber') or abs_number)
       
       # Record absolute number mapping for AniDB metadata pull

--- a/Contents/Code/TheTVDBv2.py
+++ b/Contents/Code/TheTVDBv2.py
@@ -130,10 +130,12 @@ def GetMetadata(media, movie, error_log, lang, metadata_source, AniDBid, TVDBid,
       ### ep translation
       anidbid=""
       if season!='0':  abs_number = abs_number + 1
-      if anidb_numbering:                             season, episode, anidbid = anidb_ep(mappingList, season, episode)
-      elif season!='0' and metadata_source=='tvdb3':  episode                  = str(abs_number)
-      elif season!='0' and metadata_source=='tvdb4':  season, episode          = Dict(mappingList, 'absolute_map', episode, default=(season, episode))[0], str(abs_number)
-      elif season!='0' and metadata_source=='tvdb5':  episode, abs_number      = str(Dict(episode_json, 'absoluteNumber') or abs_number), str(Dict(episode_json, 'absoluteNumber') or abs_number)
+      if anidb_numbering:
+        if season!='0' and Dict(mappingList, 'defaulttvdbseason_a'):  season, episode          = '1', str(abs_number)
+        else:                                                         season, episode, anidbid = anidb_ep(mappingList, season, episode)
+      elif season!='0' and metadata_source=='tvdb3':  episode             = str(abs_number)
+      elif season!='0' and metadata_source=='tvdb4':  season, episode     = Dict(mappingList, 'absolute_map', episode, default=(season, episode))[0], str(abs_number)
+      elif season!='0' and metadata_source=='tvdb5':  episode, abs_number = str(Dict(episode_json, 'absoluteNumber') or abs_number), int(Dict(episode_json, 'absoluteNumber') or abs_number)
       
       # Record absolute number mapping for AniDB metadata pull
       if metadata_source=='tvdb3':  SaveDict((str(Dict(episode_json, 'airedSeason')), str(Dict(episode_json, 'airedEpisodeNumber'))), mappingList, 'absolute_map', str(abs_number))

--- a/Contents/Code/TheTVDBv2.py
+++ b/Contents/Code/TheTVDBv2.py
@@ -130,9 +130,10 @@ def GetMetadata(media, movie, error_log, lang, metadata_source, AniDBid, TVDBid,
       ### ep translation
       anidbid=""
       if season!='0':  abs_number = abs_number + 1
-      if anidb_numbering:                                                      season, episode, anidbid    = anidb_ep(mappingList, season, episode)
-      elif metadata_source=='tvdb5' and Dict(episode_json, 'absoluteNumber'):  season, episode, abs_number = '1', str(Dict(episode_json, 'absoluteNumber')), str(Dict(episode_json, 'absoluteNumber'))
-      elif season!='0' and metadata_source in ('tvdb3', "tvdb4", "tvdb5"):     season, episode             = '1', str(Dict(episode_json, 'absoluteNumber') or abs_number) if metadata_source=='tvdb5' else str(abs_number)
+      if anidb_numbering:                             season, episode, anidbid = anidb_ep(mappingList, season, episode)
+      elif season!='0' and metadata_source=='tvdb3':  episode                  = str(abs_number)
+      elif season!='0' and metadata_source=='tvdb4':  season, episode          = Dict(mappingList, 'absolute_map', episode, default=(season, episode))[0], str(abs_number)
+      elif season!='0' and metadata_source=='tvdb5':  episode, abs_number      = str(Dict(episode_json, 'absoluteNumber') or abs_number), str(Dict(episode_json, 'absoluteNumber') or abs_number)
       
       # Record absolute number mapping for AniDB metadata pull
       if metadata_source=='tvdb3':  SaveDict((str(Dict(episode_json, 'airedSeason')), str(Dict(episode_json, 'airedEpisodeNumber'))), mappingList, 'absolute_map', str(abs_number))

--- a/Contents/Code/TheTVDBv2.py
+++ b/Contents/Code/TheTVDBv2.py
@@ -161,7 +161,7 @@ def GetMetadata(media, movie, error_log, lang, metadata_source, AniDBid, TVDBid,
         if not anidb_numbering:  
           SaveDict( abs_number                    , TheTVDB_dict, 'seasons', season, 'episodes', episode, 'absolute_index'         )
         SaveDict( Dict(serie_json  , 'rating'    ), TheTVDB_dict, 'seasons', season, 'episodes', episode, 'content_rating'         )
-        SaveDict( Dict(serie_json  , 'runtime'   ), TheTVDB_dict, 'seasons', season, 'episodes', episode, 'duration'               )
+        SaveDict( Dict(TheTVDB_dict, 'duration'  ), TheTVDB_dict, 'seasons', season, 'episodes', episode, 'duration'               )
         Log.Info(' - [ ] summary: {}'.format(SaveDict( Dict(episode_json, 'overview').strip(" \n\r"), TheTVDB_dict, 'seasons', season, 'episodes', episode, 'summary')))
         SaveDict( Dict(episode_json, 'firstAired'), TheTVDB_dict, 'seasons', season, 'episodes', episode, 'originally_available_at')
         

--- a/Contents/Code/TheTVDBv2.py
+++ b/Contents/Code/TheTVDBv2.py
@@ -156,7 +156,7 @@ def GetMetadata(media, movie, error_log, lang, metadata_source, AniDBid, TVDBid,
         elif metadata_source!='tvdb6':                  episode_missing_season.append( str(abs_number)+" ("+numbering+")" if metadata_source in ('tvdb3', 'tvdb4') else numbering)
         
       ### File present on disk
-      if not is_missing or metadata_source.startswith("tvdb"):
+      if not is_missing or metadata_source in ["tvdb", "tvdb6"]:  # Only pull all if anidb3(tvdb)/anidb4(tvdb6) usage
         episode_missing_season_all = False
         #Log.Info('[?] episode_json: {}'.format(episode_json))
         if not is_missing:

--- a/Contents/Code/TheTVDBv2.py
+++ b/Contents/Code/TheTVDBv2.py
@@ -143,9 +143,11 @@ def GetMetadata(media, movie, error_log, lang, metadata_source, AniDBid, TVDBid,
       else:                       summary_missing_special.append(numbering)
       
       ### Check for Missing Episodes ###
+      is_missing = False
       if not(season =='0' and episode in list_sp_eps) and \
          not(metadata_source in ('tvdb3', 'tvdb4') and str(abs_number) in list_abs_eps) and \
          not(not movie and season in media.seasons and episode in media.seasons[season].episodes):
+        is_missing = True
         Log.Info('[ ] {:>7} s{:0>2}e{:0>3} anidbid: {:>7} air_date: {}'.format(numbering, season, episode, anidbid, Dict(episode_json, 'firstAired')))
         air_date = Dict(episode_json, 'firstAired')
         air_date = int(air_date.replace('-','')) if air_date.replace('-','').isdigit() and int(air_date.replace('-','')) > 10000000 else 99999999
@@ -154,10 +156,11 @@ def GetMetadata(media, movie, error_log, lang, metadata_source, AniDBid, TVDBid,
         elif metadata_source!='tvdb6':                  episode_missing_season.append( str(abs_number)+" ("+numbering+")" if metadata_source in ('tvdb3', 'tvdb4') else numbering)
         
       ### File present on disk
-      else:
+      if not is_missing or metadata_source.startswith("tvdb"):
         episode_missing_season_all = False
         #Log.Info('[?] episode_json: {}'.format(episode_json))
-        Log.Info('[X] {:>7} s{:0>2}e{:0>3} anidbid: {:>7} air_date: {} abs_number: {}, title: {}'.format(numbering, season, episode, anidbid, Dict(episode_json, 'firstAired'), abs_number, Dict(episode_json, 'episodeName')))
+        if not is_missing:
+          Log.Info('[X] {:>7} s{:0>2}e{:0>3} anidbid: {:>7} air_date: {} abs_number: {}, title: {}'.format(numbering, season, episode, anidbid, Dict(episode_json, 'firstAired'), abs_number, Dict(episode_json, 'episodeName')))
         if not anidb_numbering:  
           SaveDict( abs_number                    , TheTVDB_dict, 'seasons', season, 'episodes', episode, 'absolute_index'         )
         SaveDict( Dict(serie_json  , 'rating'    ), TheTVDB_dict, 'seasons', season, 'episodes', episode, 'content_rating'         )

--- a/Contents/Code/TheTVDBv2.py
+++ b/Contents/Code/TheTVDBv2.py
@@ -156,7 +156,7 @@ def GetMetadata(media, movie, error_log, lang, metadata_source, AniDBid, TVDBid,
         elif metadata_source!='tvdb6':                  episode_missing_season.append( str(abs_number)+" ("+numbering+")" if metadata_source in ('tvdb3', 'tvdb4') else numbering)
         
       ### File present on disk
-      if not is_missing or metadata_source in ["tvdb", "tvdb6"]:  # Only pull all if anidb3(tvdb)/anidb4(tvdb6) usage
+      if not is_missing or metadata_source in ["tvdb", "tvdb6"]:  # Only pull all if anidb3(tvdb)/anidb4(tvdb6) usage for tvdb ep/season adjustments
         episode_missing_season_all = False
         #Log.Info('[?] episode_json: {}'.format(episode_json))
         if not is_missing:

--- a/Contents/Code/TheTVDBv2.py
+++ b/Contents/Code/TheTVDBv2.py
@@ -165,7 +165,8 @@ def GetMetadata(media, movie, error_log, lang, metadata_source, AniDBid, TVDBid,
           SaveDict( abs_number                    , TheTVDB_dict, 'seasons', season, 'episodes', episode, 'absolute_index'         )
         SaveDict( Dict(serie_json  , 'rating'    ), TheTVDB_dict, 'seasons', season, 'episodes', episode, 'content_rating'         )
         SaveDict( Dict(TheTVDB_dict, 'duration'  ), TheTVDB_dict, 'seasons', season, 'episodes', episode, 'duration'               )
-        Log.Info(' - [ ] summary: {}'.format(SaveDict( Dict(episode_json, 'overview').strip(" \n\r"), TheTVDB_dict, 'seasons', season, 'episodes', episode, 'summary')))
+        ep_summary = SaveDict( Dict(episode_json, 'overview').strip(" \n\r"), TheTVDB_dict, 'seasons', season, 'episodes', episode, 'summary' )
+        Log.Info(' - [ ] summary: {}'.format((ep_summary[:200]).replace("\n", " ")+'..' if len(ep_summary)> 200 else ep_summary))
         SaveDict( Dict(episode_json, 'firstAired'), TheTVDB_dict, 'seasons', season, 'episodes', episode, 'originally_available_at')
         
         # Title from serie page

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -120,10 +120,10 @@ def Update(metadata, media, lang, force, movie):
   #   mappingList:                  AnimeLists->TheTVDBv2/common/AniDB->AdjustMapping
   #   mappingList['season_map']:    AnimeLists->TheTVDBv2->AdjustMapping
   #   mappingList['relations_map']: AniDB->AdjustMapping
-  #   mappingList['absolute_map']:  TheTVDBv2/common->AniDB
+  #   mappingList['absolute_map']:  common->TheTVDBv2->AniDB
   dict_AnimeLists, AniDBid, TVDBid, TMDbid, IMDbid, mappingList =  AnimeLists.GetMetadata(media, movie, error_log, metadata.id)
-  dict_TheTVDB,                             IMDbid              =   TheTVDBv2.GetMetadata(media, movie, error_log, lang, source, AniDBid, TVDBid, IMDbid,         mappingList, Dict(AniDB, 'movie'))
   dict_tvdb4                                                    =      common.GetMetadata(media, movie,                  source,          TVDBid,                 mappingList)
+  dict_TheTVDB,                             IMDbid              =   TheTVDBv2.GetMetadata(media, movie, error_log, lang, source, AniDBid, TVDBid, IMDbid,         mappingList, Dict(AniDB, 'movie'))
   dict_AniDB, ANNid, MALid                                      =       AniDB.GetMetadata(media, movie, error_log,       source, AniDBid, TVDBid, AnimeLists.AniDBMovieSets, mappingList)
   dict_TheMovieDb,          TSDbid, TMDbid, IMDbid              =  TheMovieDb.GetMetadata(media, movie,                                   TVDBid, TMDbid, IMDbid)
   dict_FanartTV                                                 =    FanartTV.GetMetadata(       movie,                                   TVDBid, TMDbid, IMDbid)

--- a/Contents/Code/common.py
+++ b/Contents/Code/common.py
@@ -252,14 +252,14 @@ def DisplayDict(items={}, fields=[]):
 def DictString(input_value, max_depth, depth=0):
   """ Expand a dict down to 'max_depth' and sort the keys.
       To print it on a single line with this function use (max_depth=0).
-      If a dict is at max depth and has only one key, it will keep it on the same line.
       EX: (max_depth=1)
         mappingList: {
           'season_map': {'13493': {'max': '3', 'min': '3'}}}
-      Instead of:
+      EX: (max_depth=2)
         mappingList: {
           'season_map': {
-            '9306': {'max': '2', 'min': '1'}, '11665': {'max': '3', 'min': '3'}}}
+            '9306': {'max': '2', 'min': '1'},
+            '11665': {'max': '3', 'min': '3'}}}
   """
   output = "{" if depth == 0 else ""
   if depth >= max_depth or not isinstance(input_value, dict):
@@ -272,8 +272,8 @@ def DictString(input_value, max_depth, depth=0):
         "\n" + "  " * (depth+1) + 
         "%s: " % (('"%s"' if "'" in key else "'%s'") % key if isinstance(key, str) else key) + 
         ("{%s%s%s}" if isinstance(input_value[key], dict) else "%s%s%s") % (
-          "\n" if depth+1==max_depth and isinstance(input_value[key], dict) and len(input_value[key])>1 else "",
-          "  " * (depth+2) if isinstance(input_value[key], dict) and len(input_value[key])>1 else "", 
+          "\n" if depth==max_depth and isinstance(input_value[key], dict) else "",
+          "  " * (depth+2) if depth==max_depth and isinstance(input_value[key], dict) else "", 
           DictString(input_value[key], max_depth, depth+1)) + 
         ("," if i!=len(input_value)-1 else ""))  # remove last ','
   return output + ("}" if depth == 0 else "")

--- a/Contents/Code/common.py
+++ b/Contents/Code/common.py
@@ -263,18 +263,14 @@ def DictString(input_value, max_depth, depth=0):
   """
   output = "{" if depth == 0 else ""
   if depth >= max_depth or not isinstance(input_value, dict):
-    if   isinstance(input_value, str):   output += ('"%s"' if "'" in input_value else "'%s'") % input_value
-    elif isinstance(input_value, dict):  output += re.sub(r"^\{(?P<a>.*)\}$", r'\g<a>', "{}".format(input_value))  # remove surrounding brackets
-    else:                                output += "{}".format(input_value)
+    if isinstance(input_value, str):  output += ('"%s"' if "'" in input_value else "'%s'") % input_value
+    else:                             output += "{}".format(input_value)
   else:
     for i, key in enumerate(sorted(input_value, key=natural_sort_key)):
       output += (
         "\n" + "  " * (depth+1) + 
         "%s: " % (('"%s"' if "'" in key else "'%s'") % key if isinstance(key, str) else key) + 
-        ("{%s%s%s}" if isinstance(input_value[key], dict) else "%s%s%s") % (
-          "\n" if depth==max_depth and isinstance(input_value[key], dict) else "",
-          "  " * (depth+2) if depth==max_depth and isinstance(input_value[key], dict) else "", 
-          DictString(input_value[key], max_depth, depth+1)) + 
+        "%s" % (DictString(input_value[key], max_depth, depth+1)) + 
         ("," if i!=len(input_value)-1 else ""))  # remove last ','
   return output + ("}" if depth == 0 else "")
   # Other options passed on as can't define expansion depth

--- a/Contents/Code/common.py
+++ b/Contents/Code/common.py
@@ -742,7 +742,7 @@ def UpdateMeta(metadata, media, movie, MetaSources, mappingList):
       languages = Prefs['EpisodeLanguagePriority'].replace(' ', '').split(',')
       for episode in sorted(media.seasons[season].episodes, key=natural_sort_key):
         Log.Info("metadata.seasons[{:>2}].episodes[{:>3}]".format(season, episode))
-        new_season, new_episode = '1' if (metadata.id.startswith('tvdb3') or metadata.id.startswith('tvdb4')) and not season=='0' else season, episode
+        new_season, new_episode = season, episode
         source_title, title, rank = '', '', len(languages)+1
         for field in FieldListEpisodes:  # metadata.seasons[season].episodes[episode].attrs.keys()
           meta_old     = getattr(metadata.seasons[season].episodes[episode], field)

--- a/Contents/Code/common.py
+++ b/Contents/Code/common.py
@@ -267,7 +267,7 @@ def DictString(input_value, max_depth, depth=0):
     elif isinstance(input_value, dict):  output += re.sub(r"^\{(?P<a>.*)\}$", r'\g<a>', "{}".format(input_value))  # remove surrounding brackets
     else:                                output += "{}".format(input_value)
   else:
-    for i, key in enumerate(sorted(input_value, key=None if False in [x.isdigit() for x in input_value] else int)):
+    for i, key in enumerate(sorted(input_value, key=natural_sort_key)):
       output += (
         "\n" + "  " * (depth+1) + 
         "%s: " % (('"%s"' if "'" in key else "'%s'") % key if isinstance(key, str) else key) + 

--- a/Contents/Code/common.py
+++ b/Contents/Code/common.py
@@ -686,7 +686,7 @@ def UpdateMeta(metadata, media, movie, MetaSources, mappingList):
     meta_old    = getattr(metadata, field)
     source_list = [ source_ for source_ in MetaSources if Dict(MetaSources, source_, field) ]
     language_rank, language_source = len(languages)+1, None
-    for source in (source.strip() for source in (Prefs[field].split('|')[0] if '|' in Prefs[field] else Prefs[field]).split(',') if Prefs[field]):
+    for source in [source.strip() for source in (Prefs[field].split('|')[0] if '|' in Prefs[field] else Prefs[field]).split(',') if Prefs[field]]:
       if source in MetaSources:
         #For AniDB assigned series will favor AniDB summary even if TheTVDB is before in the source order for summary fields IF the anidb series is not mapped to TheTVDB season 1.
         if Dict(MetaSources, source, field):
@@ -727,7 +727,7 @@ def UpdateMeta(metadata, media, movie, MetaSources, mappingList):
       new_season  = season
       for field in FieldListSeasons:  #metadata.seasons[season].attrs.keys()
         meta_old = getattr(metadata.seasons[season], field)
-        for source in (source.strip() for source in Prefs[field].split(',') if Prefs[field]):
+        for source in [source.strip() for source in Prefs[field].split(',') if Prefs[field]]:
           if source in MetaSources:
             if Dict(MetaSources, source, 'seasons', season, field) or metadata.id.startswith('tvdb4'):
               if field=='posters':  season_posters_list.extend(Dict(MetaSources, source, 'seasons', season, 'posters', default={}).keys())


### PR DESCRIPTION
# Multiple Enhancements/Fixes

## RELATED ISSUES:
- https://github.com/ZeroQI/Hama.bundle/issues/269 - anidb metadata (studio not fetched)
- https://github.com/ZeroQI/Hama.bundle/issues/290 - AniDB3/4 TVDB Metadata
- https://github.com/ZeroQI/Hama.bundle/issues/292 - Dragon Ball GT [anidb-233] episode metadata

## UPDATES:
- [x] 'defaulttvdbseason'/'episodeoffset' simplification
  - [x] 'season_map' reworking. 
    - **Unexpected Bug Found/Fixed**: Issue was in the incorrect assumption that if 'a' is used, it is for the whole series. Will also get around to do a similar reworking on ASS.
```python
WAS BAD:
season_map: {'5670': {'max': 6, 'min': 6}, '1884': {'max': 0, 'min': 0}, '8279': {'max': 0, 'min': 0}, '6470': {'max': 8, 'min': 7}, '1418': {'max': 0, 'min': 0}, 'max_season': 9, '1889': {'max': 0, 'min': 0}, '343': {'max': 4, 'min': 4}, '1887': {'max': 0, 'min': 0}, '1886': {'max': 0, 'min': 0}, '11056': {'max': 9, 'min': 9}, '826': {'max': 9, 'min': 1}, '3705': {'max': 5, 'min': 5}}
-- '826': {'max': 9, 'min': 1}
NOW GOOD:
season_map: {'5670': {'max': 6, 'min': 6}, '1884': {'max': 0, 'min': 0}, '8279': {'max': 0, 'min': 0}, '6470': {'max': 8, 'min': 7}, '1418': {'max': 0, 'min': 0}, 'max_season': 9, '1889': {'max': 0, 'min': 0}, '343': {'max': 4, 'min': 4}, '1887': {'max': 0, 'min': 0}, '1886': {'max': 0, 'min': 0}, '11056': {'max': 9, 'min': 9}, '826': {'max': 3, 'min': 1}, '3705': {'max': 5, 'min': 5}}
-- '826': {'max': 3, 'min': 1}
```
  - [x] tvdb3 w/'a'. Passed
```python
Only each season start mapping posted for smaller log snippet
#########################
id: tvdb3-81618, title: Legend of the Galactic Heroes, lang: en, force: True, movie: False
...
Overriding 'defaulttvdbseason': 'a'->'1'
[+] AniDBid:   584, TVDBid:  81618, defaulttvdbseason:  1, offset:   0, name: Ginga Eiyuu Densetsu
[+] AniDBid:  1307, TVDBid:  81618, defaulttvdbseason:  0, offset:   0, name: Ginga Eiyuu Densetsu: Waga Yuku wa Hoshi no Taikai
[+] AniDBid:  1308, TVDBid:  81618, defaulttvdbseason:  0, offset:   2, name: Ginga Eiyuu Densetsu: Aratanaru Tatakai no Overture
[+] AniDBid:  1309, TVDBid:  81618, defaulttvdbseason:  0, offset:   1, name: Ginga Eiyuu Densetsu Gaiden: Ougon no Tsubasa
Saved possible tmdb/imdb values for later ('154501'/''), since not in AnimeList.
             -----          ------
               584           81618
...
AniDBid: 584, IsPrimary: True, url: <url>
...
[X] s1e  1 => s1e  1 air_date: 1988-12-21 language_rank: 0, title: "In the Eternal Night"
[X] s1e 27 => s2e 27 air_date: 1991-06-21 language_rank: 0, title: "First Battle"
[X] s1e 55 => s3e 55 air_date: 1994-07-20 language_rank: 0, title: "After the Ceremony, the Curtain Rises Once Again..."
[X] s1e 87 => s4e 87 air_date:  language_rank: 0, title: "Premonition of a Storm"
#########################
id: tvdb3-275039, title: Pretty Guardian Sailor Moon Crystal, lang: en, force: True, movie: False
...
[+] AniDBid:  9306, TVDBid: 275039, defaulttvdbseason:  1, offset:   0, name: Bishoujo Senshi Sailor Moon Crystal
    - season: [ 1],           [ 2], range:      [ 15- 26], offset: -14, text: 
[+] AniDBid: 11665, TVDBid: 275039, defaulttvdbseason:  3, offset:   0, name: Bishoujo Senshi Sailor Moon Crystal Season III
             -----          ------
              9306          275039
...
AniDBid: 9306, IsPrimary: True, url: <url>
...
[X] s1e  1 => s1e  1 air_date: 2014-06-30 language_rank: 0, title: "Usagi: Sailor Moon"
[X] s1e 15 => s2e 15 air_date: 2015-02-07 language_rank: 0, title: "Infiltration: Sailor Mars"
...
AniDBid: 11665, IsPrimary: False, url:<url>
...
[X] s1e  1 => s3e 27 air_date: 2016-03-06 language_rank: 0, title: "Infinity 1: Premonition - First Part"
```
- [x] 'AniDB' & 'TVDB' id test simplification
  - **Unexpected Bug Found/Fixed**: Looks like if fixed incorrect AnimeList collection data as was not using the winning TVDB id value
- [x] Pull AnimeLists's 'studio' for primary AniDBid
  - **Unexpected Bug Found/Fixed**: xpath path was incorrect (fix commit noted more below)
```python
id: anidb-23, title: Cowboy Bebop, lang: en, force: True, movie: False
...
[ ] collection: TVDBid '76885' is part of collection: '['Cowboy Bebop Collection']', related_anime_list: ['23', '219']
[ ] studio: Sunrise
...
AnimeLists_dict: {'collections': ['Cowboy Bebop Collection'], 'studio': 'Sunrise'}
#########################
id: tvdb-70861, title: Love Hina, lang: en, force: True, movie: False
...
[ ] collection: TVDBid '70861' is part of collection: '['Love Hina Collection']', related_anime_list: ['35', '49', '51', '52']
[ ] studio: XEBEC
...
AnimeLists_dict: {'collections': ['Love Hina Collection'], 'studio': 'XEBEC'}
```
- [x] Pull TVDB already recorded int from series level into episode
  - Confirmed duration now int and in ms
```python
      'episodes': {
        '1': {'rating': 0, 'originally_available_at': '2002-02-18', 'title': 'The Boy From Planet Zi', 
        'summary': "...", 'language_rank': 0, 'thumbs': {'https://thetvdb.plexapp.com/banners/episodes/73315/112029.jpg': ('TheTVDB/episodes/112029.jpg', 1, None)}, 
        'duration': 1800000},
```
- [x] Convert AniDB series level duration into ms
  - Confirmed duration now in ms
```python
AniDB_dict: {
  'duration': 1500000,
```
- [x] Pull all TVDB metadata if a 'tvdb' source even if missing
  - Confirmed TVDB data ep meta now present on season adjustments
```python
REMAPPING:
dict_TheTVDB Seasons Before : ['0', '1', '2']
tvdb6_seasons : {1: 1, 2: 0, 3: 2}
-- Adjusting season '1' -> '1'
-- New TVDB season  '2'
-- Adjusting season '2' -> '3'
dict_TheTVDB Seasons After  : ['0', '1', '3']

PLEX ENTRIES:
s1 = 13 episodes (tvdb s1)
s2 = 2 episodes (tvdb s0)
s3 = 13 episodes (tvdb s2)

LOG: TVDB meta now available on s3 after e2
metadata.seasons[ 3].episodes[  3]
[?] rank: 0, source_title: TheTVDB, title: "Me, That Girl, and a Stuffed Toy!"
[=] title                          Sources:  TheTVDB, AniDB| (TheTVDB), AniDB                             Inside: '['TheTVDB', 'AniDB']'  Value: 'Me, That Girl, and a Stuffed Toy!'
[=] summary                        Sources: (AniDB), TheTVDB                                              Inside: '['TheTVDB', 'AniDB']'  Value: 'When Hideyoshi's tone-deaf twin is asked to sing the school song, he's roped int..'
[=] originally_available_at        Sources: (AniDB),TheTVDB                                               Inside: '['TheTVDB', 'AniDB']'  Value: '2011-07-22'
[=] writers                        Sources: (AniDB),TheTVDB                                               Inside: '['AniDB']'  Value: 'Inoue Kenji'
[=] directors                      Sources: (AniDB),TheTVDB                                               Inside: '['AniDB']'  Value: 'Oonuma Shin'
[=] producers                      Sources: (AniDB),TheTVDB                                               Inside: '['AniDB']'  Value: 'Takayama Katsuhiko'
[x] rating                         Sources:  TheTVDB, AniDB| (TheTVDB), AniDB                             Inside: '['TheTVDB', 'AniDB']'  Value: '8.5'
[x] thumbs                   ( 1)  Sources: (TheTVDB)                                                     Inside: '['TheTVDB']'  Value: '{'https://thetvdb.plexapp.com/banners/episodes/132961/4129175.jpg': ('TheTVDB/episodes/4129175.jpg', 1, None)}'
```
- [x] Limit cases for all AniDB series & full TVDB ep meta pulls
  - Only pull all if anidb3(tvdb)/anidb4(tvdb6) usage
    - All TVDB only needed for tvdb ep/season adjustments as noted above
    - All AniDB only needed for full relation_map data required for adjustment logic
    - **Unexpected Bug Found/Fixed**: In going back to using `AniDB_array` it has been found there is a bug in its generation for tvdb3/4 (fix commit noted more below)
- [x] list comprehensions
  - Code still behaves as expected. A generator is only need if a large list and memory size is a concern. It is not in these so set to list norm.
- [x] Trim AniDB/TVDB summary log output length
  - Output confirmed
```python
TVDB:
[X]   s1e10 s01e010 anidbid:         air_date: 2006-06-10 abs_number: 10, title: The Unstoppable Chambermaid
 - [ ] summary: Roberta continues the chase as she is on top of the Black Lagoonâ€™s car trying to get back the kidnapped Garcia. After they crash into the wall of a cargo area, Revy awakens and decides to fight Robert..
 - [1] language_rank: 0, language:   en, title: The Unstoppable Chambermaid
ANIDB:
[X] s1e  2 => s1e  2 air_date: 2006-04-16 language_rank: 0, title: "Mangrove Heaven"
 - [ ] summary: The Black Lagoon is pinned down by an attack chopper, and Rock devises a risky plan to turn the tables. When itâ€™s all said and done, the disk is delivered - and the Black Lagoon gains a new crew membe..
```
- [x] A problem of not being able to map in tvdb meta pull if a single anidb series is across multiple tvdb seasons when an anidb source id entry
  - Use absolute numbering when anidb_numbering & defaulttvdbseason=='a'
- [x] anidb3/4 adjust mapping to move the s0 episodes along with its' current work of adjusting seasons
  - EX1: `id: tvdb6-252474, title: Maken-ki! Battling Venus, lang: en, force: True, movie: False`
```python
--- tvdb meta episode adjustments ---------------------------------------------------------------------------------------------------------------------------
adjustments: {
  's2e0': 
    'added': ['2', '0'],
    'deleted': {'s0e7': ('1', '1', '8566'), 's-1': {'8566': '0'}},
  's3e0': 
    'added': ['3', '0'],
    'deleted': {'s-1': {'10191': '0'}, 's0e8': ('1', '1', '10191')},
  's4e0': 
    'added': ['4', '0'],
    'deleted': {'s2': {'9406': '0'}}}
added_season: '2', added_offset: '0'
-- deleted: 's0e7': ('1', '1', '8566')
---- 's0e7'   : dict_TheTVDB['seasons']['0']['episodes']['7'] => dict_TheTVDB['seasons']['2']['episodes']['1']
-- deleted: 's-1': {'8566': '0'}
---- 's-1'    : Dead season
added_season: '3', added_offset: '0'
-- deleted: 's0e8': ('1', '1', '10191')
---- 's0e8'   : dict_TheTVDB['seasons']['0']['episodes']['8'] => dict_TheTVDB['seasons']['3']['episodes']['1']
-- deleted: 's-1': {'10191': '0'}
---- 's-1'    : Dead season
added_season: '4', added_offset: '0'
-- deleted: 's2': {'9406': '0'}
---- 's2'     : Whole season (s1+) was adjusted in previous section
```

## BUGS FOUND IN TESTING:
- [x] Fix AnimeList studio xpath
  - **Unexpected Bug Found/Fixed**: Studio was incorrect in AniDB section (copied for tvdb usage) as it had "studio" instead of actual location of "supplemental-info/studio"
- [x] Fix AnimeList collection/studio meta pull
  - Broken in update as forgot to reset `defaulttvdbseason` & `episodeoffset` variables. Now unbroken.
- [x] Fix tvdb3/tvdb4 abs mapping
  - Broken in update as removed valid if/elif test. Now unbroken.
- [x] Remove the special exception for tvdb3/4 in UpdateMeta
  - **Unexpected Bug Found/Fixed**: AniDB was correctly setting the season for both tvdb3/4 but was strangely not being used. It was found that the 'common.UpdateMeta()' function had a special exception to only look into season 1 for source of tvdb3/4.
  - This exception was removed for transparity in what is being loaded from what is recorded into meta. (MetaSeason==PlexSeason)
    - TVDB was updated to set the correct season.
    - To also have absolute data for tvdb4 mode, init meta pull order was updated along with order requirements.
- [x] Update AniDB episode existence testing
  - **Unexpected Bug Found/Fixed**:  It was incorrectly seeing episodes as missing when tvdb3/4
    - This is to better handle absolute numbering in testing
    - The if test was copied from TVDB which included 'list_abs_eps' & 'list_sp_eps' creation/testing
- [x] Fix AniDB_array generation for absolute numbering
  - **Unexpected Bug Found/Fixed**: In testing, after going back to using `AniDB_array` it has been found there is a bug in its generation for tvdb3/4.
    - If tvdb3 was being used, the entry would not be seen in the 'anidb_ep' call as was an absolute number. Convert back to normap episode number from 'absolute_map' data then call 'anidb_ep'.
    - If tvdb4 was being used, the AniDB id cannot be found as it is not using TVDB mapping. So all AniDBs will need to be pulled.
```python
EX:
Source: anidb, AniDBid: 1382, Full AniDBids list: ['1382'], Active AniDBids list: ['1382']
[+]  1382: []
#########################
Source: tvdb, AniDBid: 5975, Full AniDBids list: ['7599', '5975', '8694', '13481'], Active AniDBids list: ['7599', '5975', '8694', '13481']
[+]  7599: ['s2e1', 's2e2', 's2e3', 's2e4', 's2e5', 's2e6', 's2e7', 's2e8', 's2e9', 's2e10', 's2e11', 's2e12', 's2e13', 's2e14', 's2e15', 's2e16', 's2e17', 's2e18', 's2e19', 's2e20', 's2e21', 's2e22', 's2e23', 's2e24']
[+]  5975: ['s1e1', 's1e2', 's1e3', 's1e4', 's1e5', 's1e6', 's1e7', 's1e8', 's1e9', 's1e10', 's1e11', 's1e12', 's1e13', 's1e14', 's1e15', 's1e16', 's1e17', 's1e18', 's1e19', 's1e20', 's1e21', 's1e22', 's1e23', 's1e24']
#########################
Source: tvdb3, AniDBid: 2855, Full AniDBids list: ['2855'], Active AniDBids list: ['2855']
[+]  2855: ['s1e1', 's1e2', 's1e3', 's1e4', 's1e5', 's1e6', 's1e7', 's1e8', 's1e9', 's1e10', 's1e11', 's1e12', 's1e13', 's1e14', 's1e15', 's1e16', 's1e17', 's1e18', 's1e19', 's1e20', 's1e21', 's1e22', 's1e23', 's1e24', 's1e25', 's1e26']
#########################
Source: tvdb3, AniDBid: 9306, Full AniDBids list: ['11665', '9306'], Active AniDBids list: ['9306', '11665']
[+]  9306: ['s1e1', 's1e2', 's1e3', 's1e4', 's1e5', 's1e6', 's1e7', 's1e8', 's1e9', 's1e10', 's1e11', 's1e12', 's1e13', 's1e14', 's2e15', 's2e16', 's2e17', 's2e18', 's2e19', 's2e20', 's2e21', 's2e22', 's2e23', 's2e24', 's2e25', 's2e26']
[+] 11665: ['s3e27(s1e1)', 's3e28(s1e2)', 's3e29(s1e3)', 's3e30(s1e4)', 's3e31(s1e5)', 's3e32(s1e6)', 's3e33(s1e7)', 's3e34(s1e8)', 's3e35(s1e9)', 's3e36(s1e10)', 's3e37(s1e11)', 's3e38(s1e12)', 's3e39(s1e13)']
#########################
Source: tvdb3, AniDBid: 584, Full AniDBids list: ['584', '1307', '1308', '1309'], Active AniDBids list: ['584']
[+]   584: ['s1e1', 's1e2', 's1e3', 's1e4', 's1e5', 's1e6', 's1e7', 's1e8', 's1e9', 's1e10', 's1e11', 's1e12', 's1e13', 's1e14', 's1e15', 's1e16', 's1e17', 's1e18', 's1e19', 's1e20', 's1e21', 's1e22', 's1e23', 's1e24', 's1e25', 's1e26']
#########################
Source: tvdb4, AniDBid: 3395, Full AniDBids list: ['6645', '3395', '4597'], Active AniDBids list: ['6645', '3395', '4597']
[+]  UNKN: ['s1e1', 's1e2', 's1e3', 's1e4', 's1e5', 's1e6', 's1e7', 's1e8', 's1e9', 's1e10', 's1e11', 's1e12', 's2e13', 's2e14', 's2e15', 's2e16', 's2e17', 's2e18', 's2e19', 's2e20', 's2e21', 's2e22', 's2e23', 's2e24']
#########################
Source: tvdb6, AniDBid: 6747, Full AniDBids list: ['8235', '8085', '6747'], Active AniDBids list: ['8235', '8085', '6747']
[+]  8085: ['s0e31', 's0e32', 's0e33', 's2e1', 's2e2']
[+]  6747: ['s1e1', 's1e2', 's1e3', 's1e4', 's1e5', 's1e6', 's1e7', 's1e8', 's1e9', 's1e10', 's1e11', 's1e12', 's1e13']
[+]  8235: ['s3e1', 's3e2', 's3e3', 's3e4', 's3e5', 's3e6', 's3e7', 's3e8', 's3e9', 's3e10', 's3e11', 's3e12', 's3e13']
```
 - [x] Fix AnimeList primary id selection
    - Moved the core data pull into an internal function so code does not have to be duplicated in both the main loop and collection loop.
```
First, 'tvdb-80009' was having bad selection from:
[+] AniDBid: 2508, TVDBid: 80009, defaulttvdbseason: 1, offset: 0, name: Tenchi Muyou! Ryououki Omatsuri Zen'ya no Yoru!
- season: [ 1], [ 1], range: [000-000], offset: 0, text: 1-7;2-7;3-7
----------
Was fixed in ea8cbda by checking for "mapping-list/mapping[@anidbseason='1']"
----------
Then 'tvdb3-275039' had issue from first fix as it had correct s1->s2 mapping in:
[+] AniDBid: 9306, TVDBid: 275039, defaulttvdbseason: 1, offset: 0, name: Bishoujo Senshi Sailor Moon Crystal
- season: [ 1], [ 2], range: [ 15- 26], offset: -14, text:
----------
So was fixed again in 4a1db80 by updating to "mapping-list/mapping[@anidbseason='1'][@tvdbseason='0']".
----------
This unfortunitely unfixed the first fix. So we need to confirm there are neither s1->s0 OR s1-s1.
```

## PENDING:
None