### PR TITLE
Fix break in maketrans

### DIFF
--- a/Contents/Code/common.py
+++ b/Contents/Code/common.py
@@ -462,7 +462,7 @@ def cleanse_title(string):
   """ Cleanse title and translate anidb '`'
   """
   DeleteChars  = ""
-  ReplaceChars = maketrans("`:/*?-.,;_", "           ")  #~
+  ReplaceChars = maketrans("`:/*?-.,;_", "          ")  #~
   if len(string)<=len(String.StripDiacritics(string))+2:  string = String.StripDiacritics(string)  #else there is jap characters scrubebd outs
   try:       string2 = string.encode('ascii', 'replace')       # Encode into Ascii, prevent: UnicodeDecodeError: 'utf8' codec can't decode bytes in position 13-14: invalid continuation byte
   except:    pass


### PR DESCRIPTION
Ran into this tonight when I updated to master:

```
2020-05-13 02:08:29,837 (7f8896616700) :  CRITICAL (agentkit:1018) - Exception in the search function of agent named 'HamaMovies', called with keyword arguments {'year': '2008', 'id': '90974', 'name': 'Ghost in the Shell 2.0'} (most recent call last):
  File "/volume1/@appstore/Plex Media Server/Resources/Plug-ins-ef515a800/Framework.bundle/Contents/Resources/Versions/2/Python/Framework/api/agentkit.py", line 1011, in _search
    agent.search(*f_args, **f_kwargs)
  File "/volume1/Plex/Library/Application Support/Plex Media Server/Plug-ins/Hama.bundle/Contents/Code/__init__.py", line 168, in search
    def search (self, results,  media, lang, manual):  Search (results,  media, lang, manual, True)
  File "/volume1/Plex/Library/Application Support/Plex Media Server/Plug-ins/Hama.bundle/Contents/Code/__init__.py", line 112, in Search
    if movie or max(map(int, media.seasons.keys()))<=1:  maxi, n =         AniDB.Search(results, media, lang, manual, movie)
  File "/volume1/Plex/Library/Application Support/Plex Media Server/Plug-ins/Hama.bundle/Contents/Code/AniDB.py", line 50, in Search
    orig_title_cleansed  = common.cleanse_title(orig_title)
  File "/volume1/Plex/Library/Application Support/Plex Media Server/Plug-ins/Hama.bundle/Contents/Code/common.py", line 465, in cleanse_title
    ReplaceChars = maketrans("`:/*?-.,;_", "           ")  #~
ValueError: maketrans arguments must have same length
```

`maketrans(from, to)` requires `from` and `to` params to have the same length. https://github.com/ZeroQI/Hama.bundle/commit/77b06dd10e53fdc464f2704fb56d808c71cf8ef1 removed `~` but not a space from the second param