### PR TITLE
Fix GetAnilistIdFromAniDbId Return Value

### DIFF
--- a/Contents/Code/AniList.py
+++ b/Contents/Code/AniList.py
@@ -27,7 +27,7 @@ def GetAniListIdFromAniDbId(AniDBid):
   try:
     response = JSON.ObjectFromURL(ARM_SERVER_URL.format(id=AniDBid), cacheTime=CACHE_1WEEK)
 
-    return Dict(response, "anilist")
+    return response["anilist"]
   except Exception:
     return None
 

--- a/Contents/Code/AniList.py
+++ b/Contents/Code/AniList.py
@@ -27,7 +27,7 @@ def GetAniListIdFromAniDbId(AniDBid):
   try:
     response = JSON.ObjectFromURL(ARM_SERVER_URL.format(id=AniDBid), cacheTime=CACHE_1WEEK)
 
-    return response["anilist"]
+    return Dict(response, "anilist", default=None)
   except Exception:
     return None
 


### PR DESCRIPTION
It seems like if the value in `Dict(response, "anilist")` is null it will instead return an empty string, breaking the flow when it checks if it's `None`