### PR TITLE
Update AniDB.py

### DIFF
--- a/Contents/Code/AniDB.py
+++ b/Contents/Code/AniDB.py
@@ -401,6 +401,7 @@ def GetAniDBTitle(titles, lang=None, title_sort=False):
 def summary_sanitizer(summary):
   summary = summary.replace("`", "'")                                                                # Replace backquote with single quote
   summary = re.sub(r'https?://anidb\.net/[a-z]{1,2}[0-9]+ \[(?P<text>.+?)\]', r'\g<text>', summary)  # Replace links
+  summary = re.sub(r'https?://anidb\.net/[a-z]+/[0-9]+ \[(?P<text>.+?)\]', r'\g<text>', summary)     # Replace long-form links
   summary = re.sub(r'^(\*|--|~) .*',              "",      summary, flags=re.MULTILINE)              # Remove the line if it starts with ('* ' / '-- ' / '~ ')
   summary = re.sub(r'\n(Source|Note|Summary):.*', "",      summary, flags=re.DOTALL)                 # Remove all lines after this is seen
   summary = re.sub(r'\n\n+',                      r'\n\n', summary, flags=re.DOTALL)                 # Condense multiple empty lines


### PR DESCRIPTION
Some of the entries in my library had urls in it that escaped sanitization. After a bit of digging, it seems that the issue stems from those entries using the 'full' link in the summary, rather than the short version (e.g. "[https://anidb.net/character/270](https://anidb.net/character/270)" rather than "[https://anidb.net/ch270](https://anidb.net/ch270)".

I did a few tests and this seems to work for fixing the issue.


A more aggressive solution would be to simply match until the first whitespace character. Replacing both link-cleaning lines with:
```python
  summary = re.sub(r'https?://anidb\.net/[\S]+ \[(?P<text>.+?)\]', r'\g<text>', summary)             # Replace all links
```

The more aggressive approach seems to work fine for the titles I've tested it with, but I wasn't sure if there was a reason for the precision approach, so I opted for a similarly precise approach in the edit.