### PR TITLE
Encode title before request TVDB Search API

### DIFF
--- a/Contents/Code/TheTVDBv2.py
+++ b/Contents/Code/TheTVDBv2.py
@@ -6,6 +6,7 @@
 import os
 import time
 import re
+from urllib import quote
 # Plex Modules #
 #from collections import defaultdict
 # HAMA Modules #
@@ -347,7 +348,7 @@ def Search(results,  media, lang, manual, movie):  #if maxi<50:  maxi = tvdb.Sea
   #series_data = JSON.ObjectFromString(GetResultFromNetwork(TVDB_SEARCH_URL % mediaShowYear, additionalHeaders={'Accept-Language': lang}))['data'][0]
   orig_title = ( media.title if movie else media.show )
   maxi = 0
-  try:                    TVDBsearchXml = XML.ElementFromURL( TVDB_SERIE_SEARCH + orig_title.replace(" ", "%20"), headers=common.COMMON_HEADERS, cacheTime=CACHE_1HOUR * 24)
+  try:                    TVDBsearchXml = XML.ElementFromURL( TVDB_SERIE_SEARCH + quote(orig_title), headers=common.COMMON_HEADERS, cacheTime=CACHE_1HOUR * 24)
   except Exception as e:  Log.Error("TVDB Loading search XML failed, Exception: '%s'" % e)
   else:
     for serie in TVDBsearchXml.xpath('Series'):


### PR DESCRIPTION
Hi, I have found errors in the logs when matching Chinese title. Seems no url encoded before sending request.

```
2021-05-17 11:53:03,769 (7f09b5ffb700) :  INFO (agentkit:961) - Searching for matches for {'openSubtitlesHash': '0ab8ba0e06b2a1f4', 'episode': '11', 'name': None, 'episodic': '1', 'show': '\xe9\xbb\x91\xe4\xb9\x8b\xe5\xa5\x91\xe7\xba\xa6\xe8\x80\x85', 'season': '2', 'plexHash': '10a17064a9dde1674e4d385e97aedb54eef59c26', 'filename': '%2Fdata%2Fanimes%2Flibrary%2F%E9%BB%91%E4%B9%8B%E5%A5%91%E7%BA%A6%E8%80%85%2FSeason%2002%2F%5BPOPGO%5D%5BDarker_Than_Black_II%5D%5B11%5D%5BGB%5D%5BRV10%5D%2Ermvb', 'year': None, 'duration': '-1', 'id': '16953'}
2021-05-17 11:53:03,769 (7f09b5ffb700) :  DEBUG (networking:143) - Requesting 'http://127.0.0.1:32400/library/metadata/16953/tree'
2021-05-17 11:53:03,776 (7f09b5ffb700) :  INFO (common:135) - ==== common.PlexLog(file="/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Plug-in Support/Data/com.plexapp.agents.hama/DataItems/_Logs/动画/黑之契约者.agent-search.log")
2021-05-17 11:53:03,779 (7f09b5ffb700) :  DEBUG (networking:143) - Requesting 'https://thetvdb.com/api/GetSeries.php?seriesname=黑之契约者'
2021-05-17 11:53:03,784 (7f09b5ffb700) :  DEBUG (sandbox:19) - ERROR: TVDB Loading search XML failed, Exception: 'URL can't contain control characters. '/api/GetSeries.php?seriesname=\xe9\xbb\x91\xe4\xb9\x8b\xe5\xa5\x91\xe7\xba\xa6\xe8\x80\x85' (found at least '\xe9')'
2021-05-17 11:53:03,785 (7f09b5ffb700) :  DEBUG (runtime:88) - Sending packed state data (104 bytes)
2021-05-17 11:53:03,785 (7f09b5ffb700) :  DEBUG (runtime:924) - Response: [200] str, 320 bytes
```