### PR TITLE
Make Weighted AniDB Genres Opt In

### DIFF
--- a/Contents/Code/AniDB.py
+++ b/Contents/Code/AniDB.py
@@ -199,7 +199,7 @@ def GetMetadata(media, movie, error_log, source, AniDBid, TVDBid, AniDBMovieSets
         ### genre ###
         RESTRICTED_GENRE     = {"18 restricted": 'X', "pornography": 'X', "tv censoring": 'TV-MA', "borderline porn": 'TV-MA'}
         for tag in xml.xpath('tags/tag'):
-          if Prefs['AnidbGenresMainOnly'] and tag.get('infobox', '') or not Prefs['AnidbGenresMainOnly'] and GetXml(tag, 'name') and tag.get('weight', '').isdigit() and int(tag.get('weight', '') or '200') >= int(Prefs['MinimumWeight'] or '200'):
+          if Prefs['AnidbGenresAddWeights'] and ((int(tag.get('weight', '')) >= int(Prefs['MinimumWeight'])) or tag.get('infobox', '')) or not Prefs['AnidbGenresAddWeights'] and tag.get('infobox', ''):
             SaveDict( [string.capwords(GetXml(tag, 'name'), '-')], AniDB_dict, 'genres')
             if GetXml(tag, 'name').lower() in RESTRICTED_GENRE:  AniDB_dict['content_rating'] = RESTRICTED_GENRE[ GetXml(tag, 'name').lower() ]
         if Dict(AniDB_dict, 'genres'): AniDB_dict['genres'].sort()

--- a/Contents/Code/common.py
+++ b/Contents/Code/common.py
@@ -32,7 +32,7 @@ netLocked         = {}
 WEB_LINK          = "<a href='%s' target='_blank'>%s</a>"
 TVDB_SERIE_URL    = 'https://thetvdb.com/?tab=series&id='  # Used in error_log generation
 ANIDB_SERIE_URL   = 'https://anidb.net/anime/'             # Used in error_log generation
-DefaultPrefs      = ("SerieLanguagePriority", "EpisodeLanguagePriority", "PosterLanguagePriority", "AnidbGenresMainOnly", "MinimumWeight", "adult", "OMDbApiKey") #"Simkl", 
+DefaultPrefs      = ("SerieLanguagePriority", "EpisodeLanguagePriority", "PosterLanguagePriority", "AnidbGenresAddWeights", "MinimumWeight", "adult", "OMDbApiKey") #"Simkl", 
 FieldListMovies   = ('original_title', 'title', 'title_sort', 'roles', 'studio', 'year', 'originally_available_at', 'tagline', 'summary', 'content_rating', 'content_rating_age',
                      'producers', 'directors', 'writers', 'countries', 'posters', 'art', 'themes', 'rating', 'quotes', 'trivia', 'genres', 'collections')
 FieldListSeries   = ('title', 'title_sort', 'originally_available_at', 'duration','rating',  'reviews', 'collections', 'genres', 'tags' , 'summary', 'extras', 'countries', 'rating_count',

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -5,7 +5,7 @@
   { "id": "PosterLanguagePriority",   "label": "TheTVDB Poster Language Priority","type": "text",  "default": "en"                                                             },
   { "id": "season_poster_failover",   "label": "Season Poster failover",          "type": "enum",  "default": "None", "values" : ["None","series","series different poster"]   },
   { "id": "load_all_poster_sources",  "label": "Load all poster metadata sources","type": "bool",  "default": "false"                                                          },
-  { "id": "AnidbGenresMainOnly",      "label": "AniDB only main page genres",     "type": "bool",  "default": "false"                                                          },
+  { "id": "AnidbGenresAddWeights",    "label": "AniDB include weighted genres",   "type": "bool",  "default": "false"                                                          },
   { "id": "MinimumWeight",            "label": "AniDB genre minimum weight",      "type": "enum",  "default": "400",  "values" : ["600","500","400","300","200","100","0"]     },
   { "id": "adult",                    "label": "Include adult content",           "type": "bool",  "default": "false"                                                          },
   { "id": "OMDbApiKey",               "label": "OMDb Api Key",                    "type": "text",  "default": "None",  "option": "hidden", "secure": "true"                    },


### PR DESCRIPTION
This proposal would make AniDB genres always include the main tags that are present in the infobox while also allowing users to include additional tags based on the weight system like before if they so choose.

This is quite useful as the main genre list is generally quite small and full of important tags that the majority of people would always want to include. These tags often carry a weight of 0-200 which could be less than the one selected in the weight drop down.

