### PR TITLE
Improve AniList Logic

### DIFF
--- a/Contents/Code/AniList.py
+++ b/Contents/Code/AniList.py
@@ -9,7 +9,7 @@ import common
 from common import Log, DictString, Dict, SaveDict # Direct import of heavily used functions
 
 ### Variables ###
-ARM_SERVER_URL = "https://relations.yuna.moe/api/ids?source=anidb&id={id}"
+ARM_SERVER_URL = "https://arm.haglund.dev/api/v2/ids?source=anidb&include=anilist&id={id}"
 
 GRAPHQL_API_URL = "https://graphql.anilist.co"
 ANIME_DATA_DOCUMENT = """

--- a/Contents/Code/AniList.py
+++ b/Contents/Code/AniList.py
@@ -9,7 +9,7 @@ import common
 from common import Log, DictString, Dict, SaveDict # Direct import of heavily used functions
 
 ### Variables ###
-ARM_SERVER_URL = "https://arm.haglund.dev/api/v2/ids?source=anidb&include=anilist,myanimelist&id={id}"
+ARM_SERVER_URL = "https://arm.haglund.dev/api/v2/ids?source=anidb&include=anilist&id={id}"
 
 GRAPHQL_API_URL = "https://graphql.anilist.co"
 ANIME_DATA_DOCUMENT = """

--- a/Contents/Code/AniList.py
+++ b/Contents/Code/AniList.py
@@ -9,7 +9,7 @@ import common
 from common import Log, DictString, Dict, SaveDict # Direct import of heavily used functions
 
 ### Variables ###
-ARM_SERVER_URL = "https://arm.haglund.dev/api/v2/ids?source=anidb&include=anilist&id={id}"
+ARM_SERVER_URL = "https://arm.haglund.dev/api/v2/ids?source=anidb&include=anilist,myanimelist&id={id}"
 
 GRAPHQL_API_URL = "https://graphql.anilist.co"
 ANIME_DATA_DOCUMENT = """

--- a/Contents/Code/AniList.py
+++ b/Contents/Code/AniList.py
@@ -43,11 +43,16 @@ def GetMetadata(AniDBid, MALid):
   Log.Info("=== AniList.GetMetadata() ===".ljust(157, '='))
   AniList_dict = {}
 
-  # Try to match the AniDB id to an AniList id as it has a higher chance of being correct
-  ALid = Dict(common.LoadFile(filename=AniDBid+'.json', relativeDirectory=os.path.join('AniList', 'json', 'AniDBid'), url=ARM_SERVER_URL.format(id=AniDBid)), "anilist", default=None)
+  # Only try to get AniList ID if we have a AniDB ID
+  if AniDBid is not None:
+    # Try to match the AniDB id to an AniList id as it has a higher chance of being correct
+    ALid = Dict(common.LoadFile(filename=AniDBid+'.json', relativeDirectory=os.path.join('AniList', 'json', 'AniDBid'), url=ARM_SERVER_URL.format(id=AniDBid)), "anilist", default=None)
+  else:
+    ALid = None
 
   Log.Info("AniDBid={}, MALid={}, ALid={}".format(AniDBid, MALid, ALid))
-  if not MALid or not MALid.isdigit(): return AniList_dict
+  # Don't try to fetch data from AniList if we don't know what to fetch
+  if ALid is None and (MALid is None or not MALid.isdigit()): return AniList_dict
 
   Log.Info("--- series ---".ljust(157, "-"))
 


### PR DESCRIPTION
- Updated the URL for the ID mapping to my new domain so it can benefit from CloudFlare caching
- Updated the API endpoint to the new `v2` version that allows reducing what data is returned so we only save what's needed
- Updated logic to not send requests when there is no query data - it's currently sending quite a lot of broken requests to arm-server alone ([every 40x error in the graphs are from Hama](https://p.datadoghq.eu/sb/b1520626-b8f6-11ec-b353-da7ad0900005-0f632f4a0a35353c796a5ce6b9daeaa5))

Easier to review by [hiding whitespace diffs](https://github.com/ZeroQI/Hama.bundle/pull/536/files?w=1)

- [ ] Test it, not sure how to manually trigger shows without mal/anidb ids