### PR TITLE
AniDB vector search API

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -103,7 +103,7 @@ def Search(results, media, lang, manual, movie):
   
   # Shortcut other search methods and use vector search if enabled
   if Prefs["vector_search_enabled"] and Prefs["vector_search_api"] is not None:
-    Log.Info("Searching for '%s' using vector search API" % (orig_title))
+    Log.Debug("Searching for '%s' using vector search API" % (orig_title))
     
     api_url = "%s?name=%s" % (Prefs["vector_search_api"], urllib.quote(orig_title))
     response = HTTP.Request(api_url, cacheTime=CACHE_1DAY).content
@@ -111,17 +111,17 @@ def Search(results, media, lang, manual, movie):
 
     if "error" not in response_content:
       name = "%s [%s]" % (orig_title, response_content["id"])
-      Log.Info("Got result from vector search API: %s" % name)
+      Log.Debug("Got result from vector search API: %s" % name)
       results.Append(MetadataSearchResult(id=response_content["id"],
                                           name=name,
                                           year=media.year,
                                           lang=lang,
-                                          score=response_content["score"]*100))
+                                          score=100))
       Log.Close()
       return
     
     # Continue with normal search
-    Log.Info("Got error result from vector search API: %s" % (response_content["error"]))    
+    Log.Debug("Got error result from vector search API: %s" % (response_content["error"]))    
   
   ### Check if a guid is specified "Show name [anidb-id]" ###
   Log.Info('--- force id ---'.ljust(157, '-'))

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -1,47 +1,283 @@
 [
-  { "id": "reset_to_defaults",        "label": "Reset to Defaults",               "type": "bool",  "default": "false"                                                          },
-  { "id": "SerieLanguagePriority",    "label": "Serie Language Priority",         "type": "text",  "default": "main, en, ja"                                                   },
-  { "id": "EpisodeLanguagePriority",  "label": "Episode Language Priority",       "type": "text",  "default": "main, en, ja"                                                   },
-  { "id": "PosterLanguagePriority",   "label": "TheTVDB Poster Language Priority","type": "text",  "default": "en"                                                             },
-  { "id": "season_poster_failover",   "label": "Season Poster failover",          "type": "enum",  "default": "None", "values" : ["None","series","series different poster"]   },
-  { "id": "load_all_poster_sources",  "label": "Load all poster metadata sources","type": "bool",  "default": "false"                                                          },
-  { "id": "AnidbGenresAddWeights",    "label": "AniDB include weighted genres",   "type": "bool",  "default": "false"                                                          },
-  { "id": "MinimumWeight",            "label": "AniDB genre minimum weight",      "type": "enum",  "default": "400",  "values" : ["600","500","400","300","200","100","0"]     },
-  { "id": "adult",                    "label": "Include adult content",           "type": "bool",  "default": "false"                                                          },
-  { "id": "OMDbApiKey",               "label": "OMDb Api Key",                    "type": "text",  "default": "None",  "option": "hidden", "secure": "true"                    },
-  { "id": "title",                    "label": "T-EM 'title'",                    "type": "text",  "default": "AniDB, TheTVDB | TheTVDB, AniDB"                                },
-  { "id": "title_sort",               "label": "T-EM 'title_sort'",               "type": "text",  "default": "AniDB,TheTVDB"                                                  },
-  { "id": "originally_available_at",  "label": "T-EM 'originally_available_at'",  "type": "text",  "default": "AniDB,TheTVDB"                                                  },
-  { "id": "content_rating",           "label": "T-EM 'content_rating'",           "type": "text",  "default": "AniDB,TheTVDB"                                                  },
-  { "id": "content_rating_age",       "label": "--E- 'content_rating_age'",       "type": "text",  "default": "None"                                                           },
-  { "id": "original_title",           "label": "T-EM 'original_title'",           "type": "text",  "default": "AniDB,TheTVDB"                                                  },
-  { "id": "studio",                   "label": "T--M 'studio'",                   "type": "text",  "default": "AnimeLists, AniDB, TheMovieDb"                                  },
-  { "id": "tagline",                  "label": "T--M 'tagline'",                  "type": "text",  "default": "TheMovieDb"                                                     },
-  { "id": "summary",                  "label": "TSEM 'summary'",                  "type": "text",  "default": "TheTVDB, AniDB"                                                 },
-  { "id": "directors",                "label": "--EM 'directors'",                "type": "text",  "default": "AniDB,TheTVDB"                                                  },
-  { "id": "producers",                "label": "--EM 'producers'",                "type": "text",  "default": "AniDB,TheTVDB"                                                  },
-  { "id": "countries",                "label": "T--M 'countries",                 "type": "text",  "default": "TheMovieDb"                                                     },
-  { "id": "genres",                   "label": "T--M 'genres'",                   "type": "text",  "default": "TheTVDB, AniDB, MyAnimeList, TheMovieDb, OMDb"                  },
-  { "id": "tags",                     "label": "T--M 'tags'",                     "type": "text",  "default": "MyAnimeList"                                                    },
-  { "id": "writers",                  "label": "T-EM 'writers'",                  "type": "text",  "default": "AniDB,TheTVDB"                                                  },
-  { "id": "collections",              "label": "T--M 'collections'",              "type": "text",  "default": "Local, AniDB, TheMovieDb, AnimeLists"                           },
-  { "id": "duration",                 "label": "T--M 'duration'",                 "type": "text",  "default": "TheTVDB, AniDB, MyAnimeList, TheMovieDb, OMDb"                  },
-  { "id": "roles",                    "label": "T--M 'roles'",                    "type": "text",  "default": "AniDB, TheTVDB"                                                 },
-  { "id": "year",                     "label": "---M 'year'",                     "type": "text",  "default": "AniDB"                                                          },
-  { "id": "trivia",                   "label": "---M 'trivia'",                   "type": "text",  "default": "None"                                                           },
-  { "id": "quotes",                   "label": "---M 'quotes'",                   "type": "text",  "default": "None"                                                           },
-  { "id": "themes",                   "label": "T--M 'themes'",                   "type": "text",  "default": "TVTunes, Plex"                                                  },
-  { "id": "rating",                   "label": "T-EM 'rating'",                   "type": "text",  "default": "AniDB, TheTVDB, MyAnimeList, TheMovieDb, OMDb | TheTVDB, AniDB" },
-  { "id": "rating_image",             "label": "T--M 'rating_image'",             "type": "text",  "default": "None"                                                           },
-  { "id": "audience_rating",          "label": "T--M 'audience_rating'",          "type": "text",  "default": "None"                                                           },
-  { "id": "audience_rating_image",    "label": "T--M 'audience_rating_image'",    "type": "text",  "default": "None"                                                           },
-  { "id": "guest_stars",              "label": "T--M 'guest_stars'",              "type": "text",  "default": "TheTVDB"                                                        },
-  { "id": "posters",                  "label": "TS-M 'poster'",                   "type": "text",  "default": "tvdb4, TheMovieDb, TheTVDB, AniList, FanartTV, AniDB"           },
-  { "id": "art",                      "label": "T--M 'art'",                      "type": "text",  "default": "TheTVDB, TheMovieDb, FanartTV"                                  },
-  { "id": "banners",                  "label": "TS-- 'banners'",                  "type": "text",  "default": "TheTVDB, AniList"                                               },
-  { "id": "thumbs",                   "label": "--E- 'thumbs'",                   "type": "text",  "default": "TheTVDB"                                                        },
-  { "id": "reviews",                  "label": "T--M 'reviews'",                  "type": "text",  "default": "None"                                                           },
-  { "id": "extras",                   "label": "T--M 'extras'",                   "type": "text",  "default": "None"                                                           },
-  { "id": "rating_count",             "label": "T--M 'rating_count'",             "type": "text",  "default": "None"                                                           },
-  { "id": "absolute_index",           "label": "--E- 'absolute_index'",           "type": "text",  "default": "TheTVDB"                                                        }
+  {
+    "id": "reset_to_defaults",
+    "label": "Reset to Defaults",
+    "type": "bool",
+    "default": "false"
+  },
+  {
+    "id": "SerieLanguagePriority",
+    "label": "Serie Language Priority",
+    "type": "text",
+    "default": "main, en, ja"
+  },
+  {
+    "id": "EpisodeLanguagePriority",
+    "label": "Episode Language Priority",
+    "type": "text",
+    "default": "main, en, ja"
+  },
+  {
+    "id": "PosterLanguagePriority",
+    "label": "TheTVDB Poster Language Priority",
+    "type": "text",
+    "default": "en"
+  },
+  {
+    "id": "season_poster_failover",
+    "label": "Season Poster failover",
+    "type": "enum",
+    "default": "None",
+    "values": ["None", "series", "series different poster"]
+  },
+  {
+    "id": "load_all_poster_sources",
+    "label": "Load all poster metadata sources",
+    "type": "bool",
+    "default": "false"
+  },
+  {
+    "id": "AnidbGenresAddWeights",
+    "label": "AniDB include weighted genres",
+    "type": "bool",
+    "default": "false"
+  },
+  {
+    "id": "MinimumWeight",
+    "label": "AniDB genre minimum weight",
+    "type": "enum",
+    "default": "400",
+    "values": ["600", "500", "400", "300", "200", "100", "0"]
+  },
+  {
+    "id": "adult",
+    "label": "Include adult content",
+    "type": "bool",
+    "default": "false"
+  },
+  {
+    "id": "OMDbApiKey",
+    "label": "OMDb Api Key",
+    "type": "text",
+    "default": "None",
+    "option": "hidden",
+    "secure": "true"
+  },
+  {
+    "id": "title",
+    "label": "T-EM 'title'",
+    "type": "text",
+    "default": "AniDB, TheTVDB | TheTVDB, AniDB"
+  },
+  {
+    "id": "title_sort",
+    "label": "T-EM 'title_sort'",
+    "type": "text",
+    "default": "AniDB,TheTVDB"
+  },
+  {
+    "id": "originally_available_at",
+    "label": "T-EM 'originally_available_at'",
+    "type": "text",
+    "default": "AniDB,TheTVDB"
+  },
+  {
+    "id": "content_rating",
+    "label": "T-EM 'content_rating'",
+    "type": "text",
+    "default": "AniDB,TheTVDB"
+  },
+  {
+    "id": "content_rating_age",
+    "label": "--E- 'content_rating_age'",
+    "type": "text",
+    "default": "None"
+  },
+  {
+    "id": "original_title",
+    "label": "T-EM 'original_title'",
+    "type": "text",
+    "default": "AniDB,TheTVDB"
+  },
+  {
+    "id": "studio",
+    "label": "T--M 'studio'",
+    "type": "text",
+    "default": "AnimeLists, AniDB, TheMovieDb"
+  },
+  {
+    "id": "tagline",
+    "label": "T--M 'tagline'",
+    "type": "text",
+    "default": "TheMovieDb"
+  },
+  {
+    "id": "summary",
+    "label": "TSEM 'summary'",
+    "type": "text",
+    "default": "TheTVDB, AniDB"
+  },
+  {
+    "id": "directors",
+    "label": "--EM 'directors'",
+    "type": "text",
+    "default": "AniDB,TheTVDB"
+  },
+  {
+    "id": "producers",
+    "label": "--EM 'producers'",
+    "type": "text",
+    "default": "AniDB,TheTVDB"
+  },
+  {
+    "id": "countries",
+    "label": "T--M 'countries",
+    "type": "text",
+    "default": "TheMovieDb"
+  },
+  {
+    "id": "genres",
+    "label": "T--M 'genres'",
+    "type": "text",
+    "default": "TheTVDB, AniDB, MyAnimeList, TheMovieDb, OMDb"
+  },
+  {
+    "id": "tags",
+    "label": "T--M 'tags'",
+    "type": "text",
+    "default": "MyAnimeList"
+  },
+  {
+    "id": "writers",
+    "label": "T-EM 'writers'",
+    "type": "text",
+    "default": "AniDB,TheTVDB"
+  },
+  {
+    "id": "collections",
+    "label": "T--M 'collections'",
+    "type": "text",
+    "default": "Local, AniDB, TheMovieDb, AnimeLists"
+  },
+  {
+    "id": "duration",
+    "label": "T--M 'duration'",
+    "type": "text",
+    "default": "TheTVDB, AniDB, MyAnimeList, TheMovieDb, OMDb"
+  },
+  {
+    "id": "roles",
+    "label": "T--M 'roles'",
+    "type": "text",
+    "default": "AniDB, TheTVDB"
+  },
+  { "id": "year", "label": "---M 'year'", "type": "text", "default": "AniDB" },
+  {
+    "id": "trivia",
+    "label": "---M 'trivia'",
+    "type": "text",
+    "default": "None"
+  },
+  {
+    "id": "quotes",
+    "label": "---M 'quotes'",
+    "type": "text",
+    "default": "None"
+  },
+  {
+    "id": "themes",
+    "label": "T--M 'themes'",
+    "type": "text",
+    "default": "TVTunes, Plex"
+  },
+  {
+    "id": "rating",
+    "label": "T-EM 'rating'",
+    "type": "text",
+    "default": "AniDB, TheTVDB, MyAnimeList, TheMovieDb, OMDb | TheTVDB, AniDB"
+  },
+  {
+    "id": "rating_image",
+    "label": "T--M 'rating_image'",
+    "type": "text",
+    "default": "None"
+  },
+  {
+    "id": "audience_rating",
+    "label": "T--M 'audience_rating'",
+    "type": "text",
+    "default": "None"
+  },
+  {
+    "id": "audience_rating_image",
+    "label": "T--M 'audience_rating_image'",
+    "type": "text",
+    "default": "None"
+  },
+  {
+    "id": "guest_stars",
+    "label": "T--M 'guest_stars'",
+    "type": "text",
+    "default": "TheTVDB"
+  },
+  {
+    "id": "posters",
+    "label": "TS-M 'poster'",
+    "type": "text",
+    "default": "tvdb4, TheMovieDb, TheTVDB, AniList, FanartTV, AniDB"
+  },
+  {
+    "id": "art",
+    "label": "T--M 'art'",
+    "type": "text",
+    "default": "TheTVDB, TheMovieDb, FanartTV"
+  },
+  {
+    "id": "banners",
+    "label": "TS-- 'banners'",
+    "type": "text",
+    "default": "TheTVDB, AniList"
+  },
+  {
+    "id": "thumbs",
+    "label": "--E- 'thumbs'",
+    "type": "text",
+    "default": "TheTVDB"
+  },
+  {
+    "id": "reviews",
+    "label": "T--M 'reviews'",
+    "type": "text",
+    "default": "None"
+  },
+  {
+    "id": "extras",
+    "label": "T--M 'extras'",
+    "type": "text",
+    "default": "None"
+  },
+  {
+    "id": "rating_count",
+    "label": "T--M 'rating_count'",
+    "type": "text",
+    "default": "None"
+  },
+  {
+    "id": "absolute_index",
+    "label": "--E- 'absolute_index'",
+    "type": "text",
+    "default": "TheTVDB"
+  },
+  {
+    "id": "vector_search_enabled",
+    "label": "Use vector search API to match series/movies and circumvent other searching methods.",
+    "type": "bool",
+    "default": "false"
+  },
+  {
+    "id": "vector_search_api",
+    "label": "API of the vector search endpoint",
+    "type": "text",
+    "default": "None"
+  }
 ]

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -270,14 +270,14 @@
   },
   {
     "id": "vector_search_enabled",
-    "label": "Use vector search API to match series/movies and circumvent other searching methods.",
+    "label": "Use unofficial AniDB vector search API to match anime series/movies and circumvent other searching methods.",
     "type": "bool",
     "default": "false"
   },
   {
     "id": "vector_search_api",
-    "label": "API of the vector search endpoint",
+    "label": "URL of the AniDB vector search endpoint API. Visit https://github.com/khell/anidb-semantic-search-api to optionally host it yourself.\n\nIf you choose to use the default hosted API here. no warranties or guarantees are implied of any kind, and all queries will be transiently logged on the API server (until the next server reboot). It is strongly recommended to host the API yourself.",
     "type": "text",
-    "default": "None"
+    "default": "https://anidb.khell.net/api/anidb/id"
   }
 ]

--- a/README.md
+++ b/README.md
@@ -119,6 +119,37 @@ You can use anidb.id file in series or Series/Extras folder or in the serie name
 
 Agents' update() method is called only when adding new items to your library or when doing a "Force Refresh" or a "Fix Incorrect Match". 
 
+AniDB Vector Search
+=============
+
+You can use Khell's [AniDB vector search](https://github.com/khell/anidb-semantic-search-api) as an alternative to standard matching. To opt in, scroll down to the bottom of the agent configuration to find the settings to enable AniDB vector search. This will send your names from the scanner to the configured AniDB vector search endpoint to match it against an AniDB id. Using this means that you do not need to follow any particular naming rules for your folders, as it will use a machine-learning semantic search model to match your series name to the closest AniDB match. For example, I like to name my directories with both English and Japanese names, like so:
+
+```
+Sanzoku no Musume Ronja「山賊の娘ローニャ」
+```
+
+Previously, this sort of naming would require the suffixing of a source id to the end of the folder name, such as:
+
+```
+Sanzoku no Musume Ronja「山賊の娘ローニャ」[anidb-10421]
+```
+
+Without this prefix, the automatic matching tends to break and requires a manual Fix Match unless you follow standard naming conventions. Using this vector search, such issues are no longer a problem, as the API will return to the agent (again for the given example):
+
+```
+{"id":"anidb-10421","name":"\u5c71\u8cca\u306e\u5a18\u30ed\u30fc\u30cb\u30e3","score":0.8278500437736511}
+```
+
+The ML model currently running has additionally been trained on a large corpus of English data, which means (among other things) even partial matches or related words can work. For example, the query `Raeliana noble` will return:
+
+```
+{"id":"anidb-17498","name":"Why Raeliana Ended Up at the Duke`s Mansion","score":0.5921988487243652}
+```
+
+As a `duke` is a type of `noble`.
+
+Please note that if you choose to use the default hosted API by Khell that no warranties or guarantees are implied of any kind, and your queries will be transiently logged on the API server (until the next server reboot). It is strongly recommended you host the API yourself.
+
 Configuration
 =============
 


### PR DESCRIPTION
Thanks a lot for writing and maintaining this agent all these years.

I've added some new code to replace the default series name matching in the AniDB agent to direct the search to what I'm calling the "AniDB Vector Search API". I've described what it does in the README, but in short, it uses a machine learning model to perform semantic similarity search on a pre-generated embedding of the AniDB titles, which I intend to keep updated. This allows users to ignore the standard series naming conventions (within reason).

You can find the dataset on Huggingface here: https://huggingface.co/datasets/khellific/anidb-series-embeddings
You can find how it is used and the API source code here: https://github.com/khell/anidb-semantic-search-api

Please let me know what you think about merging this, and if there's anything you'd like for me to change. Also, while I'm hosting a version of the API for free now, I can't guarantee I'll keep it running or that it will be able to keep up with load if too many users query it as I'm only running it some spare capacity with a single worker, but as the API is open source I don't expect that to be a problem.