### PR TITLE
Add fallback request with stripped year for thetvdb

### DIFF
--- a/Contents/Code/TheTVDBv2.py
+++ b/Contents/Code/TheTVDBv2.py
@@ -360,7 +360,12 @@ def Search(results,  media, lang, manual, movie):  #if maxi<50:  maxi = tvdb.Sea
   #series_data = JSON.ObjectFromString(GetResultFromNetwork(TVDB_SEARCH_URL % mediaShowYear, additionalHeaders={'Accept-Language': lang}))['data'][0]
   orig_title = ( media.title if movie else media.show )
   maxi = 0
-  try:                    TVDBsearchXml = XML.ElementFromURL( TVDB_SERIE_SEARCH + quote(orig_title), headers=common.COMMON_HEADERS, cacheTime=CACHE_1HOUR * 24)
+  try:
+    TVDBsearchXml = XML.ElementFromURL( TVDB_SERIE_SEARCH + quote(orig_title), headers=common.COMMON_HEADERS, cacheTime=CACHE_1HOUR * 24)
+    if not TVDBsearchXml.xpath('Series'):
+      # Do a second try with the year removed from the title, if any
+      orig_title = re.sub(r'\s*\(\d{4}\)$', '', orig_title)
+      TVDBsearchXml = XML.ElementFromURL( TVDB_SERIE_SEARCH + quote(orig_title), headers=common.COMMON_HEADERS, cacheTime=CACHE_1HOUR * 24) 
   except Exception as e:  Log.Error("TVDB Loading search XML failed, Exception: '%s'" % e)
   else:
     for serie in TVDBsearchXml.xpath('Series'):


### PR DESCRIPTION
This PR fix the issue discussed at #570 (all details can be found in the issue thread), improving the out-of-the-box solution when animes are created with year in the namming schema of the series.

This is a relevant fix because the usual path for someone going from 0 to hero usually leads then to look at the TRASH guides, which recommends to configure sonarr to auto format series names with year.
