### PR TITLE
Added support for MyAnimeList beta API v2

### DIFF
--- a/Contents/Code/MyAnimeList.py
+++ b/Contents/Code/MyAnimeList.py
@@ -40,7 +40,7 @@ def GetMetadata(myanimelistIds, media_type, dict_AniDB):
     best_match, best_score = {}, -1
     season_mal_id_list = Dict(myanimelistIds, 'seasons', season)
     Log.Debug("Season: {}, MAL id list: {}".format(season, DictString(season_mal_id_list, 4)))
-    for myanimelistId in season_mal_id_list:
+    for myanimelistId in sorted(season_mal_id_list, key=natural_sort_key):
       parsed_response, current_score = {}, 0
       detailUrl = MYANIMELIST_URL_DETAILS.format(id=myanimelistId)
       Log.Info("=== MAL ID: {} ===".ljust(157, '=').format(myanimelistId))

--- a/Contents/Code/MyAnimeList.py
+++ b/Contents/Code/MyAnimeList.py
@@ -1,94 +1,134 @@
 ### MyAnimeList.net ###
-# Source agent:     https://github.com/Fribb/MyAnimeList.bundle/blob/master/Contents/Code/__init__.py
-# API xml exemple:  https://atarashii.fribbtastic.net/web/2.1/anime/33487
+# MyAnimeList API (beta ver.) (2):  https://api.myanimelist.net/v2/
+# API json exemple:                 https://api.myanimelist.net/v2/anime/{id}
+# MyAnimeList API Documentation:    https://myanimelist.net/apiconfig/references/api/v2
 
 ### Imports ###
 #import math
-import re, ssl, urllib2
-import difflib
-from datetime import datetime
-from common   import Log, Dict, SaveDict, DictString
+import re
+import os
+import time
+from common   import Log, Dict, SaveDict, DictString, UpdateDict, poster_rank, natural_sort_key, COMMON_HEADERS
 
 ### Constants ###
-MYANIMELIST_URL_SEARCH   = "https://atarashii.fribbtastic.net/web/2.1/anime/search?q={title}"
-MYANIMELIST_URL_DETAILS  = "https://atarashii.fribbtastic.net/web/2.1/anime/{id}"
-MYANIMELIST_URL_EPISODES = "https://atarashii.fribbtastic.net/web/2.1/anime/episodes/{id}?page={page}"
+MYANIMELIST_URL_SEARCH   = "https://api.myanimelist.net/v2/anime?q={title}&limit=10"
+MYANIMELIST_URL_DETAILS  = "https://api.myanimelist.net/v2/anime/{id}?fields=id,title,pictures,start_date,synopsis,mean,genres,rating,studios,media_type"
 MYANIMELIST_CACHE_TIME   = CACHE_1HOUR * 24 * 7
+RATING_VALUES            = { "g": "G - All Ages", "pg": "PG - Children", "pg_13": "PG-13 - Teens 13 and Older", "r": "R - 17+ (violence & profanity)", "r+": "R+ - Profanity & Mild Nudity", "rx": "Rx - Hentai" }
 
 ### Functions ###
-'''
-def search(name, results, lang):
-  forceID   = re.match(r'^[mal-([0-9]+)]$', str(name))
-  searchUrl = MYANIMELIST_URL_DETAILS.format(id=str(forceID.group(1))) if forceID else MYANIMELIST_URL_SEARCH.format(title=String.Quote(name, usePlus=True))
-  Log.Info("[MyAnimeList Search() - forceID {}, name: {}, searchUrl: {}".format(forceID, name, searchUrl))
-  try:                    searchResults = JSON.ObjectFromString(HTTP.Request(searchUrl, sleep=2.0, cacheTime=MYANIMELIST_CACHE_TIME).content)
-  except Exception as e:  Log.Info("search results could not be requested " + str(e));  return
-  Log.Info("Results found: " + str(len(searchResults)))
-  for series in [searchResults] if forceID else searchResults:      
-    apiAnimeId      = str(Dict(series, "id"        ))
-    apiAnimeTitle   = str(Dict(series, "title"     ))
-    apiAnimeYear    = str(Dict(series, "start_date")).split("-")[0]
-    animeMatchScore = 100 if forceID else int(difflib.SequenceMatcher(None, apiAnimeTitle, name).ratio()*100) if len(apiAnimeTitle) > 0 else 0
-    Log.Debug("Anime Found - ID={}, Title={},  Year={},  MatchScore={}".format(apiAnimeId, apiAnimeTitle, apiAnimeYear, animeMatchScore))
-    results.Append(MetadataSearchResult(id=apiAnimeId, name=apiAnimeTitle, year=apiAnimeYear, score=animeMatchScore, lang=lang))
-  return
-'''
-def GetMetadata(myanimelistId, type, media):
+def GetMetadata(myanimelistIds, media_type, dict_AniDB):
   Log.Info("=== MyAnimeList.GetMetadata() ===".ljust(157, '='))
-  detailUrl        = MYANIMELIST_URL_DETAILS.format(id=myanimelistId)
-  Log.Info("URL : "+ str(detailUrl))
-  try:                    json = JSON.ObjectFromString(HTTP.Request(detailUrl, sleep=2.0, cacheTime=MYANIMELIST_CACHE_TIME).content)
-  except Exception as e:  Log.Error("No Detail Information were available " + str(e));  return
-  result = {}
-  if json:
-    if Dict(json, "id"            ):  SaveDict(                                str(Dict(json, "id"            )  ), result, "id"                             );  Log.Debug("ID:             " + str(Dict(json, "id"            )))
-    if Dict(json, "title"         ):  SaveDict(                                str(Dict(json, "title"         )  ), result, "title"                          );  Log.Debug("Title:          " + str(Dict(json, "title"         )))
-    if Dict(json, "synopsis"      ):  SaveDict(str(re.sub(re.compile('<.*?>'), '', Dict(json, "synopsis"     ))  ), result, "summary"                        );  Log.Debug("Summary:        " + str(Dict(json, "synopsis"      )))
-    if Dict(json, "members_score" ):  SaveDict(                              float(Dict(json, "members_score" )  ), result, "rating"                         );  Log.Debug("Rating:         " + str(Dict(json, "members_score" )))
-    if Dict(json, "classification"):  SaveDict(                                str(Dict(json, "classification")  ), result, "content_rating"                 );  Log.Debug("Content Rating: " + str(Dict(json, "classification")))
-    if Dict(json, "duration"      ):  SaveDict(                                int(Dict(json, "duration")*60000  ), result, "duration"                       );  Log.Debug("Duration:       " + str(Dict(json, "duration")*60000))
-    if Dict(json, "start_date"    ):  SaveDict(                                    Dict(json, "start_date"       ), result, "originally_available_at"        );  Log.Debug("Release date:   " + str(Dict(json, "start_date"    )))
-    if Dict(json, "image_url"     ):  SaveDict(                                   (Dict(json, "image_url"),1,None), result, 'poster', Dict(json, "image_url"));  Log.Debug("Cover:          " + str(Dict(json, "image_url"     )))
-    for genre in Dict(json, "genres") if Dict(json, "genres") and len(Dict(json, "genres")) > 0 else []:
-      SaveDict([str(genre)], result, "genres")
-      Log.Debug("Genres: " + str(Dict(json, "genres")))
-    
-    ### TODO: Switch to Studios when they are available in the API (or add Producers to metadata when this is possible in Plex) 
-    #if Dict(json, "producers") and len(Dict(json, "producers")) > 0:
-    #  apiAnimeProducers = ""
-    #  for idx, producer in enumerate(Dict(json, "producers")):  apiAnimeProducers += str(producer) + ", "
-    #  SaveDict(str(apiAnimeProducers[:-2]), result, "studio")
-    #  Log.Debug("Producers: " + str(Dict(json, "producers")))
-    
-    if type == "tvshow":
-      Log.Debug("Adding TV-Show specific data")        
-      Log.Debug("Episodes: " + str(Dict(json, "episodes")))
-    #   metadata.seasons[1].episode_count = int( Dict(json, "episodes") or len(media.seasons[1].episodes))
-    #   pages = int(math.ceil(float(metadata.seasons[1].episode_count) / 100))  # fetch the episodes in 100 chunks
-    #   if pages is not None:
-    #     for page in range(1, pages + 1):
-    #       episodesUrl = MYANIMELIST_URL_EPISODES.format(id=metadata.id,page=page)
-    #       try:
-    #         Log.Info("Fetching URL " + str(episodesUrl))
-    #         episodeResult = JSON.ObjectFromString(HTTP.Request(episodesUrl, sleep=2.0, cacheTime=MYANIMELIST_CACHE_TIME).content)
-    #       except Exception as e:  Log.Info("episode results could not be requested " + str(e));  return
-    #       if "error" in episodeResult:
-    #         Log.Warn("Episode Information are not available (" + str(episodeResult["error"]) + ") (might want to add them to MyAnimeList.net)!")
-    #         break
-    #
-    #       for episode in episodeResult:
-    #         apiEpisodeNumber  = Dict(json, "number"  )
-    #         apiEpisodeTitle   = Dict(json, "title"   )
-    #         apiEpisodeAirDate = Dict(json, "air_date")
-    #         if apiEpisodeNumber is not None:
-    #           plexEpisode                         = metadata.seasons[1].episodes[int(apiEpisodeNumber)]
-    #           plexEpisode.title                   = str(apiEpisodeTitle) if apiEpisodeTitle else "Episode: #" + str(apiEpisodeNumber)
-    #           plexEpisode.originally_available_at = datetime.strptime(str(apiEpisodeAirDate), "%Y-%m-%d") if apiEpisodeAirDate else datetime.now()
-    #         Log.Debug("Episode " + str(apiEpisodeNumber) + ": " + str(apiEpisodeTitle) + " - " + str(apiEpisodeAirDate))
-    #
-    if type == "movie":
-      Log.Debug("Adding Movie specific data, nothing specific to add")
+  MainMALid = ""
+  ### Skip if Api client ID has not been initialized
+  if not (Prefs['MalApiClientID']) or Prefs['MalApiClientID'] in ('None', '', 'N/A'):
+    Log.Info("No api key found - Prefs['MalApiClientID']: '{}'".format(Prefs['MalApiClientID']))
+    ### If Mal id list exist, return first random id from first found season
+    if Dict(myanimelistIds, 'seasons'):
+      for season in sorted(Dict(myanimelistIds, 'seasons'), key=natural_sort_key):
+        MainMALid = str(Dict(myanimelistIds, 'seasons', season)[0])
+        Log.Debug("Selected MainMALid: '{}'".format(MainMALid)); break
+    return {}, MainMALid
 
-  Log.Info("MyAnimeList_dict: {}".format(DictString(result, 4)))
+  ### Setup variables for api call
+  apiClientId = Prefs['MalApiClientID']
+  headers, return_result = {}, {}
+  headers = UpdateDict(headers, COMMON_HEADERS)
+  headers = UpdateDict(headers, { 'X-MAL-CLIENT-ID': apiClientId })
+  ### Each anidb season/entry might have multiple related MAL ids. Iterate through all of them and make a 'sophisticated' guess, which one is the main entry
+  for season in sorted(Dict(myanimelistIds, 'seasons'), key=natural_sort_key):
+    best_match, best_score = {}, -1
+    season_mal_id_list = Dict(myanimelistIds, 'seasons', season)
+    Log.Debug("Season: {}, MAL id list: {}".format(season, DictString(season_mal_id_list, 4)))
+    for myanimelistId in season_mal_id_list:
+      parsed_response, current_score = {}, 0
+      detailUrl = MYANIMELIST_URL_DETAILS.format(id=myanimelistId)
+      Log.Info("=== MAL ID: {} ===".ljust(157, '=').format(myanimelistId))
+      Log.Info("URL : "+ str(detailUrl))
+      try:                    json = JSON.ObjectFromString(HTTP.Request(detailUrl, headers=headers, sleep=2.0, cacheTime=MYANIMELIST_CACHE_TIME, timeout=60).content)
+      except Exception as e:  Log.Error("No Detail Information were available " + str(e));  continue
+      ### Parse json data
+      if json:
+        parsed_id = Dict(json, "id")
+        if parsed_id:
+          SaveDict(str(parsed_id), parsed_response, "id")
+          Log.Debug("ID: " + str(parsed_id))
+        
+        parsed_title = Dict(json, "title")
+        if parsed_title: 
+          SaveDict(str(parsed_title), parsed_response, "title")
+          Log.Debug("Title: " + str(parsed_title))
+          if str(Dict(dict_AniDB, 'original_title')) == str(parsed_title): current_score += 2
+          elif str(Dict(dict_AniDB, 'original_title')) in str(parsed_title): current_score += 1
+        
+        parsed_summary = Dict(json, "synopsis")
+        if parsed_summary:
+          SaveDict(str(re.sub(re.compile('<.*?>'), '', parsed_summary)), parsed_response, "summary")
+          Log.Debug("Summary: " + str(parsed_summary))
+        
+        parsed_rating = Dict(json, "mean")
+        if parsed_rating:
+          SaveDict(float(parsed_rating), parsed_response, "rating")
+          Log.Debug("Rating: " + str(parsed_rating))
+        
+        parsed_content_rating = Dict(json, "rating")
+        if parsed_content_rating:
+          content_rating_value = Dict(RATING_VALUES, parsed_content_rating)
+          SaveDict(str(content_rating_value), parsed_response, "content_rating")
+          Log.Debug("Content Rating: " + str(content_rating_value))
+        
+        parsed_start_date = Dict(json, "start_date")
+        if parsed_start_date:
+          SaveDict(parsed_start_date, parsed_response, "originally_available_at")
+          Log.Debug("Release date: " + str(parsed_start_date))
+          if str(Dict(dict_AniDB, 'originally_available_at')) in str(parsed_start_date): current_score += 1
+
+        parsed_pictures = Dict(json, "pictures")
+        if parsed_pictures and len(parsed_pictures) > 0:
+          for picture_entry in parsed_pictures:
+            poster_file_url = str(Dict(picture_entry, "medium"))
+            poster_file_name = poster_file_url.split("/")[len(poster_file_url.split("/"))-1]
+            poster_entry_value = ( os.path.join('MyAnimeList', 'poster', poster_file_name), poster_rank('MyAnimeList', 'posters'), None)
+            SaveDict(poster_entry_value, parsed_response, 'posters', poster_file_url)
+            Log.Debug("Cover: " + str(poster_file_name))
+        
+        parsed_studios = Dict(json, "studios")
+        if parsed_studios:
+          studio = ", ".join(str(Dict(x, "name")) for x in parsed_studios)
+          SaveDict(str(studio), parsed_response, "studio")
+          Log.Debug("Studios: " + str(studio))
+        
+        parsed_genres = Dict(json, "genres")
+        for genre in parsed_genres if parsed_genres and len(parsed_genres) > 0 else []:
+          genre_name = Dict(genre, "name")
+          SaveDict([str(genre_name)], parsed_response, "genres")
+          Log.Debug("Genres: " + str(genre_name))
+
+        parsed_media_type = Dict(json, "media_type")
+        if parsed_media_type:
+          if str(parsed_media_type) == str(media_type): current_score += 2
+          elif str(parsed_media_type) == str("ova"): current_score += 1
+        
+        ### Check the result of data compare to anidb and replace the selection if better result
+        Log.Debug("Mal id: {}, Compare score: {}".format(myanimelistId, current_score))
+        if current_score > best_score:
+          best_score = current_score
+          best_match = parsed_response
+
+      ### In case there is multiple entries to fetch, Sleep between to prevent overload on mal api
+      if len(season_mal_id_list) > 2: time.sleep(1)
+    
+    if Dict(best_match, "id"):
+      ### Save best match data on season level
+      SaveDict(Dict(best_match, 'summary'), return_result, 'seasons', season, 'summary')
+      SaveDict(Dict(best_match, 'title'), return_result, 'seasons', season, 'title')
+      SaveDict(Dict(best_match, 'posters'), return_result, 'seasons', season, 'posters')
+      ### Save first found best match data on series level
+      if not Dict(return_result, "id"):
+        UpdateDict(return_result, best_match)
+        MainMALid = Dict(best_match, 'id')
+        Log.Debug("Selected MainMALid: '{}'".format(MainMALid))
+
+  Log.Info("MyAnimeList_dict: {}".format(DictString(return_result, 4)))
   Log.Info("--- return ---".ljust(157, '-'))
-  return result
+  return return_result, MainMALid

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -138,23 +138,23 @@ def Update(metadata, media, lang, force, movie):
   dict_AnimeLists, AniDBid, TVDBid, TMDbid, IMDbid, mappingList =  AnimeLists.GetMetadata(media, movie, error_log, metadata.id)
   dict_tvdb4                                                    =       tvdb4.GetMetadata(media, movie,                  source,          TVDBid,                 mappingList)
   dict_TheTVDB,                             IMDbid              =   TheTVDBv2.GetMetadata(media, movie, error_log, lang, source, AniDBid, TVDBid, IMDbid,         mappingList)
-  dict_AniDB, ANNid, MALid                                      =       AniDB.GetMetadata(media, movie, error_log,       source, AniDBid, TVDBid, AnimeLists.AniDBMovieSets, mappingList)
+  dict_AniDB, ANNid, MALids                                     =       AniDB.GetMetadata(media, movie, error_log,       source, AniDBid, TVDBid, AnimeLists.AniDBMovieSets, mappingList)
   dict_TheMovieDb,          TSDbid, TMDbid, IMDbid              =  TheMovieDb.GetMetadata(media, movie,                                   TVDBid, TMDbid, IMDbid)
   dict_FanartTV                                                 =    FanartTV.GetMetadata(       movie,                                   TVDBid, TMDbid, IMDbid)
   dict_Plex                                                     =        Plex.GetMetadata(metadata, error_log, TVDBid, Dict(dict_TheTVDB, 'title'))
   dict_TVTunes                                                  =     TVTunes.GetMetadata(metadata, Dict(dict_TheTVDB, 'title'), Dict(mappingList, AniDBid, 'name'))  #Sources[m:eval('dict_'+m)]
   dict_OMDb                                                     =        OMDb.GetMetadata(movie, IMDbid)  #TVDBid=='hentai'
-  #dict_MyAnimeList                                              = MyAnimeList.GetMetadata(MALid, "movie" if movie else "tvshow", media)
-  dict_AniList                                                  =     AniList.GetMetadata(AniDBid, MALid)
+  dict_MyAnimeList, MainMALid                                   = MyAnimeList.GetMetadata(MALids, "movie" if movie else "tv", dict_AniDB)
+  dict_AniList                                                  =     AniList.GetMetadata(AniDBid, MainMALid)
   dict_Local                                                    =       Local.GetMetadata(media, movie)
   if anidb34.AdjustMapping(source, mappingList, dict_AniDB, dict_TheTVDB, dict_FanartTV):
-    dict_AniDB, ANNid, MALid                                    =       AniDB.GetMetadata(media, movie, error_log,       source, AniDBid, TVDBid, AnimeLists.AniDBMovieSets, mappingList)
+    dict_AniDB, ANNid, MALids                                   =       AniDB.GetMetadata(media, movie, error_log,       source, AniDBid, TVDBid, AnimeLists.AniDBMovieSets, mappingList)
   Log.Info('=== Update() ==='.ljust(157, '='))
-  Log.Info("AniDBid: '{}', TVDBid: '{}', TMDbid: '{}', IMDbid: '{}', ANNid:'{}', MALid: '{}'".format(AniDBid, TVDBid, TMDbid, IMDbid, ANNid, MALid))
+  Log.Info("AniDBid: '{}', TVDBid: '{}', TMDbid: '{}', IMDbid: '{}', ANNid:'{}', MALid: '{}'".format(AniDBid, TVDBid, TMDbid, IMDbid, ANNid, MainMALid))
   common.write_logs(media, movie, error_log, source, AniDBid, TVDBid)
   common.UpdateMeta(metadata, media, movie, {'AnimeLists': dict_AnimeLists, 'AniDB':       dict_AniDB,       'TheTVDB': dict_TheTVDB, 'TheMovieDb': dict_TheMovieDb, 
                                              'FanartTV':   dict_FanartTV,   'tvdb4':       dict_tvdb4,       'Plex':    dict_Plex,    'TVTunes':    dict_TVTunes, 
-                                             'OMDb':       dict_OMDb,       'Local':       dict_Local,       'AniList': dict_AniList}, mappingList) #, 'MyAnimeList': dict_MyAnimeList
+                                             'OMDb':       dict_OMDb,       'Local':       dict_Local,       'AniList': dict_AniList, 'MyAnimeList': dict_MyAnimeList}, mappingList)
   Log.Info("end: {}".format(datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S,%f")))
   Log.Close()
 

--- a/Contents/Code/common.py
+++ b/Contents/Code/common.py
@@ -705,9 +705,9 @@ def UpdateMeta(metadata, media, movie, MetaSources, mappingList):
     season_posters_list = []
     for season in sorted(media.seasons, key=natural_sort_key):  # For each season, media, then use metadata['season'][season]...
       Log.Info(("metadata.seasons[{:>2}]".format(season)).ljust(157, '-'))
-      source_list = [ source_ for source_ in MetaSources if Dict(MetaSources, source_, 'seasons', season, field) ]
       new_season  = season
       for field in FieldListSeasons:  #metadata.seasons[season].attrs.keys()
+        source_list = [ source_ for source_ in MetaSources if Dict(MetaSources, source_, 'seasons', season, field) ]
         meta_old = getattr(metadata.seasons[season], field)
         if field in ('posters', 'banners', 'art'):  meta_old.validate_keys([])  #This will allow the images to get readded at the correct priority level if preferences are updates and meta is refreshed
         for source in [source.strip() for source in Prefs[field].split(',') if Prefs[field]]:

--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -9,6 +9,7 @@
   { "id": "MinimumWeight",            "label": "AniDB genre minimum weight",      "type": "enum",  "default": "400",  "values" : ["600","500","400","300","200","100","0"]     },
   { "id": "adult",                    "label": "Include adult content",           "type": "bool",  "default": "false"                                                          },
   { "id": "OMDbApiKey",               "label": "OMDb Api Key",                    "type": "text",  "default": "None",  "option": "hidden", "secure": "true"                    },
+  { "id": "MalApiClientID",           "label": "MyAnimeList Api ClientID",        "type": "text",  "default": "",      "option": "hidden", "secure": "true"                    },
   { "id": "title",                    "label": "T-EM 'title'",                    "type": "text",  "default": "AniDB, TheTVDB | TheTVDB, AniDB"                                },
   { "id": "title_sort",               "label": "T-EM 'title_sort'",               "type": "text",  "default": "AniDB,TheTVDB"                                                  },
   { "id": "originally_available_at",  "label": "T-EM 'originally_available_at'",  "type": "text",  "default": "AniDB,TheTVDB"                                                  },


### PR DESCRIPTION
I wanted to get the rank score from MyAnimeList, so I updated the old MyAnimeList.GetMetaData to work with the new API.

Changes:

- Added new setting field for MAL API ClientID
- Refactored the whole MyAnimeList.GetMetaData(), removed the old redundant code
- Get all related MAL ids from AniDb, instead of first random one, and pick the most relevant one
- Gets data to Series and Season level

The old version had a problem, that it selected the first related MAL id from the AniDb data that it found and used that one. Not to mention in multiple season cases it picked up the id from last searched season. So on top of possibly being from random season, it also possibly was from some random special episode, that had own entry in MAL.
Changed the code so that it picks up all the ids related to AniDb season (season 0 entries excluded) and then, makes a api call for each one and by comparing some fields to the AniDb data, it will make a guess for the main entry. I did test this with my library that has over hundred series entries, and it did work on all of them, that had right MAL ids in the AniDb data.

Data fields, that are fetched to the Series level from earliest found Season data:

- id
- title
- summary
- rating
- content_rating
- posters
- originally_available_at
- genres
- studio

And then, following data fields are fetch for each individual Season:

- title
- summary
- posters

These are basically all the relevant data fields, that the MAL API supports.

I did add title and summary to the season level, as there is data fields for those on Plex UI, but I have no idea are these even supposed to work? The metadata update handler in common.py doesn't recognize the title field, but the summary field gets updated and still doesn't show at all on Plex. Please let me know, if you do know how this works. It would also be nice to get the rating value on Season level, but I have no idea if this is Plex dependent thing or this plugin. Posters at least are working on the Season level.

New MAL api needs a ClientID, so whoever wants to get the metadata from MAL needs to first go generate new ClientID from MAL and add it to the settings.

Thank you for your work on this plugin, it has already helped me a lot! Glad if I'm able to contribute

Also fixed season level source_list variable in common.py. This probably didn't have any other affect than logging not showing this data