### PR TITLE
Use official TheTVDB CDN instead of broken Plex proxy

### DIFF
--- a/Contents/Code/TheTVDBv2.py
+++ b/Contents/Code/TheTVDBv2.py
@@ -16,7 +16,7 @@ import AnimeLists
 
 ### Variables ###
 TVDB_API_KEY               = 'A27AD9BE0DA63333'
-TVDB_IMG_ROOT              = 'https://thetvdb.plexapp.com/banners/' 
+TVDB_IMG_ROOT              = 'https://artworks.thetvdb.com/banners/' 
 TVDB_BASE_URL              = 'https://api.thetvdb.com'  #'https://api-beta.thetvdb.com' #tvdb v2 plex proxy site'' # TODO Start using TVDB's production api (TVDB is behind CF) when available and possibly a plex proxy for it
 TVDB_LOGIN_URL             = TVDB_BASE_URL + '/login'
 TVDB_LOGIN_REFRESH_URL     = TVDB_BASE_URL + '/refresh_token'

--- a/Contents/Code/common.py
+++ b/Contents/Code/common.py
@@ -452,7 +452,7 @@ def metadata_download(metadata, metatype, url, filename="", num=99, url_thumbnai
     try:
       if filename and Data.Exists(filename):  status += ", Found locally"; file = Data.Load(filename)
       else:
-        file = (ssl_open((url_thumbnail or url).replace('thetvdb.com', 'thetvdb.plexapp.com')) if 'thetvdb.com' in url else False) or ssl_open(url_thumbnail or url)
+        file = ssl_open(url_thumbnail or url)
         if file:  status += ", Downloaded and Saved locally";  SaveFile(filename, file)
       if file:  metatype[ url ] = Proxy.Preview(file, sort_order=num) if url_thumbnail else Proxy.Media(file, sort_order=num) # or metatype[ url ] != proxy_item # proxy_item = 
     except Exception as e:  Log.Info("common.metadata_download() - Exception: {}, url: '{}', filename: '{}'".format(e, url, filename));  return


### PR DESCRIPTION
Fixes #596

## Problem

TheTVDB images fail to download with HTTP 405 errors when using Plex's proxy at `thetvdb.plexapp.com`.

## Solution

Use TheTVDB's official CDN (`artworks.thetvdb.com`) instead of Plex's proxy.

This is the URL format returned by TheTVDB's v4 API (see thetvdb/v4-api#306). The Plex proxy was a caching layer that is no longer working reliably.

## Changes

- `TheTVDBv2.py`: Change `TVDB_IMG_ROOT` to use `artworks.thetvdb.com`
- `common.py`: Remove proxy replacement logic (no longer needed)

## Testing

Tested with The Apothecary Diaries (2023) - episode thumbnails now download correctly.