### PR TITLE
Fix TypeError when tvdbseason/TVDBid is None in anime-list mappings

### DIFF
--- a/Contents/Code/AnimeLists.py
+++ b/Contents/Code/AnimeLists.py
@@ -116,9 +116,9 @@ def GetMetadata(media, movie, error_log, id):
     defaulttvdbseason, episodeoffset, s1_mapping_count, is_primary_series = anime_core(anime)
 
     if not tvdb_numbering and not TVDB_id:                                                      TVDB_id2  = TVDBid
-    if tvdb_numbering and AniDBid and TVDBid.isdigit() and is_primary_series and not AniDB_id:  AniDB_id2 = AniDBid
-    Log.Info("[+] AniDBid: {:>5}, TVDBid: {:>6}, defaulttvdbseason: {:>4}, offset: {:>3}, TMDBid: {:>7}, IMDBid: {:>10}, name: {}".format(AniDBid, TVDBid, 
-      ("({})".format(anime.get('defaulttvdbseason')) if anime.get('defaulttvdbseason')!=defaulttvdbseason else '')+defaulttvdbseason, episodeoffset, 
+    if tvdb_numbering and AniDBid and (TVDBid or "").isdigit() and is_primary_series and not AniDB_id:  AniDB_id2 = AniDBid
+    Log.Info("[+] AniDBid: {:>5}, TVDBid: {:>6}, defaulttvdbseason: {:>4}, offset: {:>3}, TMDBid: {:>7}, IMDBid: {:>10}, name: {}".format(AniDBid, TVDBid or "", 
+      ("({})".format(anime.get('defaulttvdbseason')) if anime.get('defaulttvdbseason')!=defaulttvdbseason else '')+str(defaulttvdbseason or ''), episodeoffset, 
       TMDBid, IMDBid, GetXml(anime, 'name')))
     
     ### AniDB/TMDB/IMDB numbered series ###
@@ -138,7 +138,7 @@ def GetMetadata(media, movie, error_log, id):
       for art   in anime.xpath('supplemental-info/fanart/thumb'):  SaveDict({art.text:('/'.join(art.text.split('/')[3:]), 1, art.get('preview'))}, AnimeLists_dict, 'art'   )
       
     ### TheTVDB/multi-season numbered series and the Primary/Starting(s1e1) AniDB id ###
-    if (TVDB_id or not movie and max(map(int, media.seasons.keys()))>1 and AniDB_id=='') and TVDBid.isdigit() and is_primary_series:
+    if (TVDB_id or not movie and max(map(int, media.seasons.keys()))>1 and AniDB_id=='') and (TVDBid or "").isdigit() and is_primary_series:
       AniDB_id2 = AniDBid
       SaveDict(TMDBid,                                                 mappingList, 'tmdbid'             )
       SaveDict(IMDBid,                                                 mappingList, 'imdbid'             )
@@ -150,8 +150,8 @@ def GetMetadata(media, movie, error_log, id):
     elif not defaulttvdbseason.isdigit(): tvdbid, defaulttvdbseason = '', ''
     
     ### TheTVDB ###
-    if TVDBid.isdigit():
-      SaveDict(episodeoffset, mappingList, 'TVDB', 's-1' if defaulttvdbseason == '0' and s1_mapping_count >= 1 else 's'+defaulttvdbseason, AniDBid)  #mappingList['TVDB'][s1][anidbid]=episodeoffset
+    if (TVDBid or "").isdigit():
+      SaveDict(episodeoffset, mappingList, 'TVDB', 's-1' if defaulttvdbseason == '0' and s1_mapping_count >= 1 else 's'+str(defaulttvdbseason or '1'), AniDBid)  #mappingList['TVDB'][s1][anidbid]=episodeoffset
       SaveDict({'min': defaulttvdbseason, 'max': defaulttvdbseason}, mappingList, 'season_map', AniDBid)  # Set the min/max season to the 'defaulttvdbseason'
       if source=="tvdb6" and int(episodeoffset)>0:  SaveDict({'min': '0', 'max': '0'}, mappingList, 'season_map', AniDBid)  # Force series as special if not starting the TVDB season
 
@@ -160,24 +160,24 @@ def GetMetadata(media, movie, error_log, id):
         Log.Info("    - season: [{:>2}],           [{:>2}], range:       [{:>3}-{:>3}], offset: {:>3}, text: {}".format(anidbseason, tvdbseason, start or '000', end or '000', offset, (season.text or '').strip(';')))
         for ep in range(int(start), int(end or '0')+1)        if start       else []:
           #Log.Info("[?] start: {}, end: {}, ep: {}".format(start, end, ep))
-          if not Dict(mappingList, 'TVDB', 's'+tvdbseason+'e'+str(ep+int(offset))):
-            SaveDict((anidbseason, str(ep),          AniDBid), mappingList, 'TVDB', 's'+tvdbseason+'e'+str(ep+int(offset)) ) #mappingList['TVDB'][s1e1]=(AniDB_season, AniDB_episode, AniDBid) for start-end mappings
+          if not Dict(mappingList, 'TVDB', 's'+str(tvdbseason or '1')+'e'+str(ep+int(offset))):
+            SaveDict((anidbseason, str(ep),          AniDBid), mappingList, 'TVDB', 's'+str(tvdbseason or '1')+'e'+str(ep+int(offset)) ) #mappingList['TVDB'][s1e1]=(AniDB_season, AniDB_episode, AniDBid) for start-end mappings
           #else: Log.Info("already present")
         for ep in filter(None, season.text.split(';')) if season.text else []:
           if not '-' in ep:
             Log.Info('[!] MAPPING ERROR, season.text: "{}", ep mapping missing hyphen: "{}"'.format(season.text, ep))
-          elif not Dict(mappingList, 'TVDB', 's'+tvdbseason+'e'+ep.split('-')[1]):
-            SaveDict((anidbseason, ep.split('-')[0], AniDBid), mappingList, 'TVDB', 's'+tvdbseason+'e'+ep.split('-')[1])     #mappingList['TVDB'][s1e1]=(AniDB_season, AniDB_episode, AniDBid) for manual mapping like '1-12'
-          #elif '-' not in (mappingList, 'TVDB', 's'+tvdbseason+'e'+ep.split('-')[1]):
-          #  SaveDict((anidbseason, Dict(mappingList, 'TVDB', 's'+tvdbseason+'e'+ep.split('-')[1])[1]+'-'+ep.split('-')[0], AniDBid), mappingList, 'TVDB', 's'+tvdbseason+'e'+ep.split('-')[1])
+          elif not Dict(mappingList, 'TVDB', 's'+str(tvdbseason or '1')+'e'+ep.split('-')[1]):
+            SaveDict((anidbseason, ep.split('-')[0], AniDBid), mappingList, 'TVDB', 's'+str(tvdbseason or '1')+'e'+ep.split('-')[1])     #mappingList['TVDB'][s1e1]=(AniDB_season, AniDB_episode, AniDBid) for manual mapping like '1-12'
+          #elif '-' not in (mappingList, 'TVDB', 's'+str(tvdbseason or '1')+'e'+ep.split('-')[1]):
+          #  SaveDict((anidbseason, Dict(mappingList, 'TVDB', 's'+str(tvdbseason or '1')+'e'+ep.split('-')[1])[1]+'-'+ep.split('-')[0], AniDBid), mappingList, 'TVDB', 's'+str(tvdbseason or '1')+'e'+ep.split('-')[1])
           #  Log.Info("already present so converting to range but range not supported")
-        if int(Dict(mappingList, 'season_map', AniDBid, 'max')) < int(season.get("tvdbseason")):
+        if season.get("tvdbseason") is not None and int(Dict(mappingList, 'season_map', AniDBid, 'max')) < int(season.get("tvdbseason")):
           SaveDict(season.get("tvdbseason"), mappingList, 'season_map', AniDBid, 'max')  # Update the max season to the largest 'tvdbseason' season seen in 'mapping-list'
     
     ### 
     if TVDBid=="hentai":  SaveDict("X", AnimeLists_dict, 'content_rating')
     elif TVDBid in ("", "unknown", None):
-      link = SCUDLEE_FEEDBACK.format(title="[HAMA] AniDB ID:%s" % AniDB_id, anidb_title=GetXml(anime, 'name'), anidb_id=AniDB_id)
+      link = SCUDLEE_FEEDBACK.format(title="[HAMA] AniDB ID:%s" % AniDB_id, anidb_title=GetXml(anime, 'name').replace('{', '(').replace('}', ')'), anidb_id=AniDB_id)
       error_log['anime-list TVDBid missing'].append('AniDBid: "{}" | Title: "{}" | Has no matching TVDBid "{}" in mapping file | <a href="{}" target="_blank">Submit bug report</a>'.format(AniDB_id, "title", TVDBid, link))
       Log.Info('"anime-list TVDBid missing.htm" log added as tvdb serie id missing in mapping file: "{}"'.format("None" if TVDBid is None else TVDBid))
         


### PR DESCRIPTION
## Problem

  Some entries in `anime-list-master.xml` (ScudLee) have `tvdbseason` set to `None` —
  notably One Piece (tvdb-81797) which has dozens of AniDB sub-entries. This causes
  `TypeError: cannot concatenate 'str' and 'NoneType' objects` when fetching metadata.

  ## Changes

  - `TVDBid.isdigit()` → `(TVDBid or "").isdigit()` — guard against `None`
  - `'s'+tvdbseason+'e'+...` → `'s'+str(tvdbseason or '1')+'e'+...` — fallback to season 1
  when mapping is absent
  - `'s'+defaulttvdbseason` → `'s'+str(defaulttvdbseason or '1')` — same concatenation fix
  - `int(season.get("tvdbseason"))` → added `is not None` guard — `int(None)` crashes
  - Sanitize anime name in `SCUDLEE_FEEDBACK.format()` to prevent `KeyError` from curly
  braces in titles